### PR TITLE
Handle the case when idx exceeds img boundary

### DIFF
--- a/SpatialAveragePooling.cu
+++ b/SpatialAveragePooling.cu
@@ -50,14 +50,19 @@ __global__ void subsample(float *input, float *output,
       float *ptr_input = input + yy*dH*input_w + xx*dW;
       float *ptr_output = output + yy*output_w + xx;
       float sum = 0;
+      int nElements = 0;
       int kx, ky;
       for(ky = 0; ky < kH; ky++) {
-        for(kx = 0; kx < kW; kx++)
-          sum += ptr_input[kx];
+        for(kx = 0; kx < kW; kx++) {
+          if((xx*dW+kx < input_w) & (yy*dH+ky < input_h)) {
+            sum += ptr_input[kx];
+            nElements++;
+          }
+        }
         ptr_input += input_w; // next input line
       }
       // Update output
-      *ptr_output = sum / float(kW*kH);
+      *ptr_output = sum / float(nElements);
     }
   }
 }

--- a/SpatialMaxPooling.cu
+++ b/SpatialMaxPooling.cu
@@ -60,12 +60,14 @@ __global__ void maxpool(float *input, float *output, float *indices_x, float *in
       int kx, ky;
       for(ky = 0; ky < kH; ky++) {
         for(kx = 0; kx < kW; kx++) {
-          float val = ptr_input[kx];
-          if (val > max) {
-            max = val;
-            argmax_x = kx;
-            argmax_y = ky;
-          } 
+          if((xx*dW+kx < input_w) & (yy*dH+ky < input_h)) {
+            float val = ptr_input[kx];
+            if (val > max) {
+              max = val;
+              argmax_x = kx;
+              argmax_y = ky;
+            }
+          }
         }
         ptr_input += input_w; // next input line
       }


### PR DESCRIPTION
SpatialAverage(Max)Pooling gives incorrect numbers on the boundary of the
image when the input image has a remainder while computing output.