### PR TITLE
gradient tests for inn.ROIPooling, nnf.ROIPooling; also comparison of their outputs

### DIFF
--- a/test/nnf.ROIPooling.lua
+++ b/test/nnf.ROIPooling.lua
@@ -1,0 +1,86 @@
+local ROIPooling,parent = torch.class('nnf.ROIPooling','nn.Module')
+
+function ROIPooling:__init(W,H)
+  parent.__init(self)
+  self.W = W
+  self.H = H
+  self.pooler = {}--nn.SpatialAdaptiveMaxPooling(W,H)
+  self.spatial_scale = 1
+  self.gradInput = {torch.Tensor()}
+end
+
+function ROIPooling:setSpatialScale(scale)
+  self.spatial_scale = scale
+  return self
+end
+
+function ROIPooling:updateOutput(input)
+  local data = input[1]
+  local rois = input[2]
+
+  local num_rois = rois:size(1)
+  local s = data:size()
+  local ss = s:size(1)
+  self.output:resize(num_rois,s[ss-2],self.H,self.W)
+
+  rois[{{},{2,5}}]:add(-1):mul(self.spatial_scale):add(1):round()
+  rois[{{},2}]:cmin(s[ss])
+  rois[{{},3}]:cmin(s[ss-1])
+  rois[{{},4}]:cmin(s[ss])
+  rois[{{},5}]:cmin(s[ss-1])
+
+  -- element access is faster if not a cuda tensor
+  if rois:type() == 'torch.CudaTensor' then
+    self._rois = self._rois or torch.FloatTensor()
+    self._rois:resize(rois:size()):copy(rois)
+    rois = self._rois
+  end
+
+  if not self._type then self._type = output:type() end
+
+  if #self.pooler < num_rois then
+    local diff = num_rois - #self.pooler
+    for i=1,diff do
+      table.insert(self.pooler,nn.SpatialAdaptiveMaxPooling(self.W,self.H):type(self._type))
+    end
+  end
+
+  for i=1,num_rois do
+    local roi = rois[i]
+    local im_idx = roi[1]
+    local im = data[{im_idx,{},{roi[3],roi[5]},{roi[2],roi[4]}}]
+    self.output[i] = self.pooler[i]:updateOutput(im)
+  end
+  return self.output
+end
+
+function ROIPooling:updateGradInput(input,gradOutput)
+  local data = input[1]
+  local rois = input[2]
+  if rois:type() == 'torch.CudaTensor' then
+    rois = self._rois
+  end
+  local num_rois = rois:size(1)
+  local s = data:size()
+  local ss = s:size(1)
+  self.gradInput[1]:resizeAs(data):zero()
+
+  for i=1,num_rois do
+    local roi = rois[i]
+    local im_idx = roi[1]
+    local r = {im_idx,{},{roi[3],roi[5]},{roi[2],roi[4]}}
+    local im = data[r]
+    local g  = self.pooler[i]:updateGradInput(im,gradOutput[i])
+    self.gradInput[1][r]:add(g)
+  end
+  return self.gradInput
+end
+
+function ROIPooling:type(type)
+  parent.type(self,type)
+  for i=1,#self.pooler do
+    self.pooler[i]:type(type)
+  end
+  self._type = type
+  return self
+end

--- a/test/test_jacobian.lua
+++ b/test/test_jacobian.lua
@@ -121,6 +121,118 @@ function inntest.SpatialSameResponseNormalization()
 end
 
 
+function randROI(sz, n)
+    assert(sz:size()==4, "need 4d size")
+    local roi=torch.Tensor(n,5)
+    for i=1,n do
+        idx=torch.randperm(sz[1])[1]
+        y=torch.randperm(sz[3])[{{1,2}}]:sort()
+        x=torch.randperm(sz[4])[{{1,2}}]:sort()
+        roi[{i,{}}] = torch.Tensor({idx,x[1],y[1],x[2],y[2]})
+    end
+    return roi
+end
+
+function testJacobianWithRandomROI(cls)
+    --pooling grid size
+    local w=4; 
+    local h=4;
+    --input size 
+    local W=w*2;
+    local H=h*2;
+
+    local batchSize = 3
+    local numRoi = batchSize
+    torch.manualSeed(0)
+    print('\nTesting module '.. torch.type(cls))
+    for i=1,3 do
+        print(i)
+        local input = torch.rand(batchSize, 1, H, W);
+        local roi=randROI(input:size(), numRoi)
+        local module=cls.new(h, w, 1, roi)
+        local err=jac.testJacobian(module, input, nil, nil, 1e-3)
+        print(err)
+        mytester:assertlt(err, precision, 'error on RoiPooling')
+    end
+end
+
+function inntest.ROIPooling()
+    local FixedROIPooling, parent = torch.class('FixedROIPooling', 'inn.ROIPooling')
+    function FixedROIPooling:__init(W, H, s, roi)
+        self.roi = roi 
+        parent.__init(self, W, H, s)
+        self:cuda()
+    end
+
+    function FixedROIPooling:updateOutput(input)
+        return parent.updateOutput(self,{input:cuda(), self.roi})
+    end
+    function FixedROIPooling:updateGradInput(input, gradOutput)
+        return parent.updateGradInput(self,{input:cuda(), self.roi}, gradOutput)[1]
+    end
+
+    testJacobianWithRandomROI(FixedROIPooling)
+
+end
+
+nnf={}
+dofile('nnf.ROIPooling.lua')
+function inntest.NNFROIPooling()
+    local FixedROIPooling, parent = torch.class('NNFFixedROIPooling', 'nnf.ROIPooling')
+    function FixedROIPooling:__init(W, H, s, roi)
+        self.roi = roi 
+        parent.__init(self, W, H)
+        parent.setSpatialScale(self, s)
+        self:cuda()
+    end
+
+    function FixedROIPooling:updateOutput(input)
+        return parent.updateOutput(self,{input:cuda(), self.roi})
+    end
+    function FixedROIPooling:updateGradInput(input, gradOutput)
+        return parent.updateGradInput(self,{input:cuda(), self.roi}, gradOutput)[1]
+    end
+
+    testJacobianWithRandomROI(FixedROIPooling)
+end
+
+function inntest.compareNNFAndINNROIPooling()
+    --pooling grid size
+    local w=4; 
+    local h=4;
+    local scale=1;
+    --input size 
+    local W=w*2;
+    local H=h*2;
+
+    local batchSize = 3
+    local numRoi = batchSize
+    torch.manualSeed(0)
+    for i=1,3 do
+        local input = torch.rand(batchSize, 1, H, W);
+        local roi=randROI(input:size(), numRoi)
+        local innModule=inn.ROIPooling(w, h, scale, roi)
+        local nnfModule=nnf.ROIPooling(w, h, roi); nnfModule:setSpatialScale(scale)
+
+        innModule:cuda()
+        nnfModule:cuda()
+        local inputs = {input:cuda(), roi:cuda()}
+
+        local innOutput=innModule:forward(inputs)
+        local nnfOutput=nnfModule:forward(inputs)
+        local err=(innOutput:view(-1)-nnfOutput:view(-1)):norm()
+        mytester:assertlt(err, precision, 'error comparing two ROIPooling forward()')
+
+        gradOutput= torch.rand(batchSize, 1, h, w):cuda()
+        innGrad=innModule:backward(inputs, gradOutput)[1]
+        nnfGrad=nnfModule:backward(inputs, gradOutput)[1]
+        local err=(innGrad:view(-1) - nnfGrad:view(-1)):norm()
+        mytester:assertlt(err, precision, 'error comparing two ROIPooling backward()')
+
+    end
+
+end
+
 jac = nn.Jacobian
 mytester:add(inntest)
 mytester:run()


### PR DESCRIPTION
## my crude implementation of the Jacobian check for nnf.ROIPooling and inn.ROIPooling. 

I made the following not so comfortable choices but not sure if there were any better solutions. 

1. nnf.ROIPooling.lua is copied from the object-detection.torch project/fast-rcnn branch for comparison.
2. In order to use nn.Jacobian for Gradient testing, I had to subclass both ROIPooling methods such that the subclassed forward()/backward() take single input tensor instead of {input,ROI}.

## Some observations running test_jacobian.lua

1. SpatialSameResponseNormalization fails. (same failiure in master branch as well).
```
tingfan@X:~/dnn/imagine-nn/test$ th ./test_jacobian.lua 
Running 3 tests	
_*_  ==> Done Completed 10 asserts in 3 tests with 2 errors	
--------------------------------------------------------------------------------
SpatialSameResponseNormalization
error on state 
 LT(<) violation   val=nan, condition=0.001
	...tingfan/dnn/torch/install/share/lua/5.1/torch/Tester.lua:26: in function 'assertlt'
	./test_jacobian.lua:112: in function <./test_jacobian.lua:103>
```

2. The two ROIPooling methods give very close results (2-norm diff <1e-7).
3. The gradient tests pass most of time (diff<1e-3), but not always. Both methods fail at the same test case . Maybe you could help  point out some incorrect input? 
```
tingfan@X:~/dnn/imagine-nn/test$ th ./test_jacobian.lua 
Running 6 tests	
___|__  ==> NnfROIPooling                    
Testing module nnf.ROIPooling	
test no 1	
err 4.6730041503906e-05	
test no 2	
err 4.6730041503906e-05	
test no 3	
err 0.025642871856689	
___**|  ==> InnROIPooling                   
Testing module inn.ROIPooling	
test no 1	
err 4.6730041503906e-05	
test no 2	
err 4.6730041503906e-05	
test no 3	
err 0.025642871856689	
```