### PR TITLE
Add ROIWarping layer described in the winning solution of ILSVRC & MSCOCO 2015 competition (http://arxiv.org/abs/1512.04412). 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.swp
-*.swo
+*.sw*
+*.bak*
 build
 build/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.swp
+*.swo
+build
+build/*

--- a/ROIPooling.lua
+++ b/ROIPooling.lua
@@ -9,7 +9,8 @@ function ROIPooling:__init(W,H,spatial_scale)
   self.spatial_scale = spatial_scale or 1
   self.gradInput = {}
   self.indices = torch.Tensor()
-  self.v2 = true
+  --self.v2 = true
+  self.v2 = false
 end
 
 function ROIPooling:setSpatialScale(scale)

--- a/ROIPooling.lua
+++ b/ROIPooling.lua
@@ -9,8 +9,7 @@ function ROIPooling:__init(W,H,spatial_scale)
   self.spatial_scale = spatial_scale or 1
   self.gradInput = {}
   self.indices = torch.Tensor()
-  --self.v2 = true
-  self.v2 = false
+  self.v2 = true
 end
 
 function ROIPooling:setSpatialScale(scale)

--- a/ROIWarping.cu
+++ b/ROIWarping.cu
@@ -1,0 +1,348 @@
+// ------------------------------------------------------------------
+// Fast R-CNN
+// Copyright (c) 2015 Microsoft
+// Licensed under The MIT License [see fast-rcnn/LICENSE for details]
+// Written by Ross Girshick
+// ------------------------------------------------------------------
+
+// Torch port:
+// IMAGINE, Sergey Zagoruyko, Francisco Massa, 2015
+
+#include "THC.h"
+#include <algorithm>
+#include <cfloat>
+
+#include "common.h"
+
+
+using std::max;
+using std::min;
+
+
+template <typename Dtype>
+__global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
+    const Dtype spatial_scale, const int channels, const int height,
+    const int width, const int pooled_height, const int pooled_width,
+    const Dtype* bottom_rois, const Dtype* bottom_delta_rois, Dtype* top_data, int* argmax_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    // (n, c, ph, pw) is an element in the pooled output
+    int pw = index % pooled_width;
+    int ph = (index / pooled_width) % pooled_height;
+    int c = (index / pooled_width / pooled_height) % channels;
+    int n = index / pooled_width / pooled_height / channels;
+
+    bottom_rois += n * 5;
+    int roi_batch_ind = (bottom_rois[0] - 1);
+    //int roi_start_w = round((bottom_rois[1] - 1) * spatial_scale);
+    //int roi_start_h = round((bottom_rois[2] - 1)* spatial_scale);
+    //int roi_end_w = round((bottom_rois[3] - 1) * spatial_scale);
+    //int roi_end_h = round((bottom_rois[4] - 1) * spatial_scale);
+
+    Dtype src_w = bottom_rois[3] - bottom_rois[1] + 1; 
+    Dtype src_h = bottom_rois[4] - bottom_rois[2] + 1;
+    Dtype src_ctr_x = bottom_rois[1] + 0.5*(src_w-1.0); 
+    Dtype src_ctr_y = bottom_rois[2] + 0.5*(src_h-1.0); 
+
+    Dtype dst_ctr_x = bottom_delta_rois[1]; // dx
+    Dtype dst_ctr_y = bottom_delta_rois[2]; // dy
+    Dtype dst_scl_x = bottom_delta_rois[3]; // dw
+    Dtype dst_scl_y = bottom_delta_rois[4]; // dh
+
+    Dtype pred_ctr_x = dst_ctr_x * src_w + src_ctr_x;
+    Dtype pred_ctr_y = dst_ctr_y * src_h + src_ctr_y;
+    Dtype pred_w = exp(dst_scl_x) * src_w;
+    Dtype pred_h = exp(dst_scl_y) * src_h;
+
+    int roi_start_w = ( max(1., round(pred_ctr_x - 0.5*(pred_w-1)))      - 1 ) * spatial_scale;
+    int roi_start_h = ( max(1., round(pred_ctr_y - 0.5*(pred_h-1)))      - 1 ) * spatial_scale;
+    int roi_end_w =   ( min(static_cast<Dtype>(height), round(pred_ctr_x + 0.5*(pred_w-1))) - 1 ) * spatial_scale;
+    int roi_end_h =   ( min(static_cast<Dtype>(width), round(pred_ctr_y + 0.5*(pred_h-1)))  - 1 ) * spatial_scale; 
+
+    // Force malformed ROIs to be 1x1
+    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+    Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                       / static_cast<Dtype>(pooled_height);
+    Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                       / static_cast<Dtype>(pooled_width);
+
+    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
+                                        * bin_size_h));
+    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)
+                                        * bin_size_w));
+    int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)
+                                     * bin_size_h));
+    int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)
+                                     * bin_size_w));
+
+    Dtype hctr = static_cast<Dtype>(hend-1+hstart)/2.; 
+    Dtype wctr = static_cast<Dtype>(wend-1+wstart)/2.; 
+
+    // Add roi offsets and clip to input boundaries
+    hstart = min(max(hstart + roi_start_h, 0), height);
+    hend = min(max(hend + roi_start_h, 0), height);
+    wstart = min(max(wstart + roi_start_w, 0), width);
+    wend = min(max(wend + roi_start_w, 0), width);
+    //bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+    Dtype hdiff = static_cast<Dtype>(hend-1-hstart);  
+    Dtype wdiff = static_cast<Dtype>(wend-1-wstart);
+
+    // Define an empty pooling region to be zero
+    //Dtype maxval = is_empty ? 0 : -FLT_MAX;
+    Dtype val = 0; Dtype gain = 0, gain_x = 0, gain_y = 0;   
+    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
+    //int maxidx = -1;
+    bottom_data += (roi_batch_ind * channels + c) * height * width;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        int bottom_index = h * width + w;
+        //if (bottom_data[bottom_index] > maxval) {
+        //  maxval = bottom_data[bottom_index];
+        //  maxidx = bottom_index;
+        //}
+        //gain_x = max(0., 1 - abs( dst_ctr_x + static_cast<Dtype>(pw) / static_cast<Dtype>(pooled_width) * dst_scl_x - w ));
+        //gain_y = max(0., 1 - abs( dst_ctr_y + static_cast<Dtype>(ph) / static_cast<Dtype>(pooled_height) * dst_scl_y - h));
+        gain_x = (wdiff - abs((static_cast<Dtype>(w) - wctr))) / static_cast<Dtype>(wdiff);
+        gain_y = (hdiff - abs((static_cast<Dtype>(h) - hctr))) / static_cast<Dtype>(hdiff); 
+        gain = gain_x * gain_y;
+        val = val + gain * bottom_data[bottom_index];
+        //val = val + gain;
+      }
+    }
+    //top_data[index] = maxval;
+    //argmax_data[index] = maxidx;
+    top_data[index] = val;
+  }
+}
+
+extern "C"
+void inn_ROIWarping_updateOutput(THCState *state,
+    THCudaTensor *output, THCudaTensor *indices,
+    THCudaTensor *data, THCudaTensor* rois, THCudaTensor* delta_rois, int W, int H, double spatial_scale)
+{
+  THAssert(THCudaTensor_nDimension(state, data) == 4);
+  THAssert(THCudaTensor_nDimension(state, rois) == 2 && rois->size[1] == 5);
+  THAssert(THCudaTensor_nDimension(state, delta_rois) == 2 && delta_rois->size[1] == 5);
+  THAssert(THCudaTensor_nDimension(state, rois) == THCudaTensor_nDimension(state, delta_rois) &&
+           rois->size[0] == delta_rois->size[0] &&
+           rois->size[1] == delta_rois->size[1]);
+  THAssert(THCudaTensor_isContiguous(state, data));
+  THAssert(THCudaTensor_isContiguous(state, rois));
+  THAssert(THCudaTensor_isContiguous(state, delta_rois));
+  long num_rois = rois->size[0];
+  long nInputPlane = data->size[1];
+  THCudaTensor_resize4d(state, output, num_rois, nInputPlane, H, W);
+  THCudaTensor_resize4d(state, indices, num_rois, nInputPlane, H, W);
+
+  long count = THCudaTensor_nElement(state, output);
+
+  ROIWarpForward<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+      count,
+      THCudaTensor_data(state, data),
+      spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
+      THCudaTensor_data(state, rois),
+      THCudaTensor_data(state, delta_rois),
+      THCudaTensor_data(state, output),
+      (int*)THCudaTensor_data(state, indices)
+      );
+
+  // check for errors
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("error in inn_ROIWarping_updateOutput: %s\n", cudaGetErrorString(err));
+    THError("aborting");
+  }
+}
+
+/*
+extern "C"
+void inn_ROIWarping_updateOutput(THCState *state,
+    THCudaTensor *output, THCudaTensor *indices,
+    THCudaTensor *data, THCudaTensor* rois, int W, int H, double spatial_scale)
+{
+  THAssert(THCudaTensor_nDimension(state, data) == 4);
+  THAssert(THCudaTensor_nDimension(state, rois) == 2 && rois->size[1] == 5);
+  THAssert(THCudaTensor_isContiguous(state, data));
+  THAssert(THCudaTensor_isContiguous(state, rois));
+  long num_rois = rois->size[0];
+  long nInputPlane = data->size[1];
+  THCudaTensor_resize4d(state, output, num_rois, nInputPlane, H, W);
+  THCudaTensor_resize4d(state, indices, num_rois, nInputPlane, H, W);
+
+  long count = THCudaTensor_nElement(state, output);
+
+  ROIWarpForward<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+      count,
+      THCudaTensor_data(state, data),
+      spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
+      THCudaTensor_data(state, rois),
+      THCudaTensor_data(state, output),
+      (int*)THCudaTensor_data(state, indices)
+      );
+
+  // check for errors
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("error in inn_ROIWarping_updateOutput: %s\n", cudaGetErrorString(err));
+    THError("aborting");
+  }
+}
+*/
+/*
+template <typename Dtype>
+__global__ void ROIWarpForwardV2(const int nthreads, const Dtype* bottom_data,
+    const Dtype spatial_scale, const int channels, const int height,
+    const int width, const int pooled_height, const int pooled_width,
+    const Dtype* bottom_rois, Dtype* top_data, int* argmax_data)  {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    // (n, c, ph, pw) is an element in the pooled output
+    int pw = index % pooled_width;
+    int ph = (index / pooled_width) % pooled_height;
+    int c = (index / pooled_width / pooled_height) % channels;
+    int n = index / pooled_width / pooled_height / channels;
+
+    bottom_rois += n * 5;
+    int roi_batch_ind = (bottom_rois[0] - 1);
+    int roi_start_w = round((bottom_rois[1] - 1) * spatial_scale);
+    int roi_start_h = round((bottom_rois[2] - 1)* spatial_scale);
+    int roi_end_w = round((bottom_rois[3] - 1) * spatial_scale) - 1;
+    int roi_end_h = round((bottom_rois[4] - 1) * spatial_scale) - 1;
+
+    // Force malformed ROIs to be 1x1
+    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+    Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                       / static_cast<Dtype>(pooled_height);
+    Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                       / static_cast<Dtype>(pooled_width);
+
+   int hstart = static_cast<int>(round(static_cast<Dtype>(ph)
+                                       * bin_size_h));
+   int wstart = static_cast<int>(round(static_cast<Dtype>(pw)
+                                       * bin_size_w));
+   int hend = static_cast<int>(round(static_cast<Dtype>(ph + 1)
+                                    * bin_size_h));
+   int wend = static_cast<int>(round(static_cast<Dtype>(pw + 1)
+                                    * bin_size_w));
+
+    // Add roi offsets and clip to input boundaries
+    hstart = min(max(hstart + roi_start_h, 0), height);
+    hend = min(max(hend + roi_start_h, 0), height);
+    wstart = min(max(wstart + roi_start_w, 0), width);
+    wend = min(max(wend + roi_start_w, 0), width);
+    bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+    // Define an empty pooling region to be zero
+    Dtype maxval = is_empty ? 0 : -FLT_MAX;
+    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
+    int maxidx = -1;
+    bottom_data += (roi_batch_ind * channels + c) * height * width;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        int bottom_index = h * width + w;
+        if (bottom_data[bottom_index] > maxval) {
+          maxval = bottom_data[bottom_index];
+          maxidx = bottom_index;
+        }
+      }
+    }
+    top_data[index] = maxval;
+    argmax_data[index] = maxidx;
+  }
+}
+
+extern "C"
+void inn_ROIWarping_updateOutputV2(THCState *state,
+    THCudaTensor *output, THCudaTensor *indices,
+    THCudaTensor *data, THCudaTensor* rois, int W, int H, double spatial_scale)
+{
+  THAssert(THCudaTensor_nDimension(state, data) == 4);
+  THAssert(THCudaTensor_nDimension(state, rois) == 2 && rois->size[1] == 5);
+  THAssert(THCudaTensor_isContiguous(state, data));
+  THAssert(THCudaTensor_isContiguous(state, rois));
+  long num_rois = rois->size[0];
+  long nInputPlane = data->size[1];
+  THCudaTensor_resize4d(state, output, num_rois, nInputPlane, H, W);
+  THCudaTensor_resize4d(state, indices, num_rois, nInputPlane, H, W);
+
+  long count = THCudaTensor_nElement(state, output);
+
+  ROIWarpForwardV2<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+      count,
+      THCudaTensor_data(state, data),
+      spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
+      THCudaTensor_data(state, rois),
+      THCudaTensor_data(state, output),
+      (int*)THCudaTensor_data(state, indices)
+      );
+
+  // check for errors
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("error in inn_ROIWarping_updateOutput: %s\n", cudaGetErrorString(err));
+    THError("aborting");
+  }
+}
+*/
+
+template <typename Dtype>
+__global__ void ROIWarpBackwardAtomic(const int nthreads, const Dtype* top_diff,
+    const int* argmax_data, const int num_rois, const Dtype spatial_scale,
+    const int channels, const int height, const int width,
+    const int pooled_height, const int pooled_width, Dtype* bottom_diff,
+    const Dtype* bottom_rois) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    // (n, c, ph, pw) is an element in the pooled output
+    int pw = index % pooled_width;
+    int ph = (index / pooled_width) % pooled_height;
+    int c = (index / pooled_width / pooled_height) % channels;
+    int n = index / pooled_width / pooled_height / channels;
+
+    bottom_rois += n * 5;
+    int roi_batch_ind = (bottom_rois[0] - 1);
+    int bottom_offset = (roi_batch_ind * channels + c) * height * width;
+    int top_offset    = (n * channels + c) * pooled_height * pooled_width;
+    const Dtype* offset_top_diff = top_diff + top_offset;
+    Dtype* offset_bottom_diff = bottom_diff + bottom_offset;
+    const int* offset_argmax_data = argmax_data + top_offset;
+
+    int argmax = offset_argmax_data[ph*pooled_width + pw];
+    if(argmax != -1) {
+      atomicAdd(offset_bottom_diff + argmax, offset_top_diff[ph * pooled_width + pw]);
+    }
+  }
+}
+
+extern "C"
+void inn_ROIWarping_updateGradInputAtomic(THCState *state,
+    THCudaTensor *gradInput, THCudaTensor *indices, THCudaTensor *data,
+    THCudaTensor *gradOutput, THCudaTensor* rois, int W, int H, double spatial_scale)
+{
+  THAssert(THCudaTensor_nDimension(state, data) == 4);
+  THAssert(THCudaTensor_nDimension(state, rois) == 2 && rois->size[1] == 5);
+  THAssert(THCudaTensor_isContiguous(state, data));
+  THAssert(THCudaTensor_isContiguous(state, rois));
+  long num_rois = rois->size[0];
+  long nInputPlane = data->size[1];
+  THCudaTensor_resizeAs(state, gradInput, data);
+  THCudaTensor_zero(state, gradInput);
+
+  long count = THCudaTensor_nElement(state, gradOutput);
+
+  ROIWarpBackwardAtomic<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+      count,
+      THCudaTensor_data(state, gradOutput),
+      (int*)THCudaTensor_data(state, indices),
+      num_rois, spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
+      THCudaTensor_data(state, gradInput),
+      THCudaTensor_data(state, rois)
+      );
+
+  // check for errors
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("error in inn_ROIWarping_updateGradInputAtomic: %s\n", cudaGetErrorString(err));
+    THError("aborting");
+  }
+}

--- a/ROIWarping.cu
+++ b/ROIWarping.cu
@@ -24,7 +24,7 @@ template <typename Dtype>
 __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
     const Dtype spatial_scale, const int channels, const int height,
     const int width, const int pooled_height, const int pooled_width,
-    const Dtype* bottom_rois, const Dtype* bottom_delta_rois, Dtype* top_data/*, int* argmax_data*/) {
+    const Dtype* bottom_rois, const Dtype* bottom_delta_rois, Dtype* top_data, Dtype* top_data_buffer) {
   CUDA_KERNEL_LOOP(index, nthreads) {
     // (n, c, ph, pw) is an element in the pooled output
     int pw = index % pooled_width;
@@ -54,10 +54,10 @@ __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
     Dtype pred_w = exp(dst_scl_x) * src_w;            // dpw  / dsx = src_w * exp(dsx)  
     Dtype pred_h = exp(dst_scl_y) * src_h;            // dph  / dsy = src_h * exp(dsy)  
     
-    int roi_start_w = ( round(pred_ctr_x - 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drsw / dpcx = spatial_scale; drsw / dpw = -0.5 * spatial_scale
-    int roi_start_h = ( round(pred_ctr_y - 0.5*(pred_h-1)) - 1 ) * spatial_scale; // drsh / dpcy = spatial_scale; drsh / dph = -0.5 * spatial_scale
-    int roi_end_w =   ( round(pred_ctr_x + 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drew / dpcx = spatial_scale; drew / dpw =  0.5 * spatial_scale
-    int roi_end_h =   ( round(pred_ctr_y + 0.5*(pred_h-1)) - 1 ) * spatial_scale; // dreh / dpcy = spatial_scale; dreh / dph =  0.5 * spatial_scale
+    Dtype roi_start_w = ( (pred_ctr_x - 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drsw / dpcx = spatial_scale; drsw / dpw = -0.5 * spatial_scale
+    Dtype roi_start_h = ( (pred_ctr_y - 0.5*(pred_h-1)) - 1 ) * spatial_scale; // drsh / dpcy = spatial_scale; drsh / dph = -0.5 * spatial_scale
+    Dtype roi_end_w =   ( (pred_ctr_x + 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drew / dpcx = spatial_scale; drew / dpw =  0.5 * spatial_scale
+    Dtype roi_end_h =   ( (pred_ctr_y + 0.5*(pred_h-1)) - 1 ) * spatial_scale; // dreh / dpcy = spatial_scale; dreh / dph =  0.5 * spatial_scale
     assert(roi_end_w - roi_start_w >= 0);
     assert(roi_end_h - roi_start_h >= 0);   
     
@@ -74,32 +74,38 @@ __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
     // dreh / dsy = dreh / dph * dph / dsy =  0.5 * spatial_scale * src_h * exp(dsy) 
  
     // Force malformed ROIs to be 1x1
-    int roi_width  = roi_end_w - roi_start_w + 1;    // drw / drew = (rew - rsw) > 0 ?  1 : 0 
-                                                    // drw / drsw = (rew - rsw) > 0 ? -1 : 0
-    int roi_height = roi_end_h - roi_start_h + 1;   // drh / dreh = (reh - rsh) > 0 ?  1 : 0
-                                                    // drh / drsh = (reh - rsh) > 0 ? -1 : 0
+    Dtype roi_width  = roi_end_w - roi_start_w + 1; // drw / drew =  1
+                                                    // drw / drsw = -1
+    Dtype roi_height = roi_end_h - roi_start_h + 1; // drh / dreh =  1
+                                                    // drh / drsh = -1
     // drw / dcx = drw / drew * drew / dcx + drw / drsw * drsw / dcx = drew / dcx - drsw / dcx = spatial_scale * src_w - spatial_scale * src_w = 0 
     // drh / dcy = drh / dreh * dreh / dcy + drh / drsh * drsh / dcy = dreh / dcy - drsh / dcy = spatial_scale * src_h - spatial_scale * src_h = 0 
     // drw / dsx = drw / drew * drew / dsx + drw / drsw * drsw / dsx = drew / dsx - drsw / dsx = 0.5 * spatial_scale * src_w * exp(dsx) - (-0.5 * spatial_scale * src_w * exp(dsx)) = spatial_scale * src_w * exp(dsx) 
     // drh / dsy = drh / dreh * dreh / dsy + drh / drsh * drsh / dsy = dreh / dsy - drsh / dsy = 0.5 * spatial_scale * src_h * exp(dsy) - (-0.5 * spatial_scale * src_h * exp(dsy)) = spatial_scale * src_h * exp(dsy) 
     
-    Dtype bin_size_w = static_cast<Dtype>(roi_width)
-                       / static_cast<Dtype>(pooled_width);  // dbw / drw  =  1 / pooled_width
-    Dtype bin_size_h = static_cast<Dtype>(roi_height)         
-                       / static_cast<Dtype>(pooled_height); // dbh / drh  =  1 / pooled_height
+    Dtype bin_size_w = roi_width  / static_cast<Dtype>(pooled_width);  // dbw / drw  =  1 / pooled_width
+    Dtype bin_size_h = roi_height / static_cast<Dtype>(pooled_height); // dbh / drh  =  1 / pooled_height
     // dbw / dcx = dbw / drw * drw / dcx = 0 
     // dbh / dcy = dbh / drh * drh / dcy = 0
     // dbw / dsx = dbw / drw * drw / dsx = 1 / pooled_width * spatial_scale * src_w * exp(dsx) 
     // dbh / dsy = dbh / drh * drh / dsy = 1 / pooled_height * spatial_scale * src_h * exp(dsy) 
 
-    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)        // dws / dbw = pw 
-                                        * bin_size_w)) + roi_start_w; // dws / drsw = 1
-    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)        // dhs / dbh = ph 
-                                        * bin_size_h)) + roi_start_h; // dhs / drsh = 1 
+    //int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)        // dws / dbw = pw 
+    //                                    * bin_size_w)) + roi_start_w; // dws / drsw = 1
+    //int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)        // dhs / dbh = ph 
+    //                                    * bin_size_h)) + roi_start_h; // dhs / drsh = 1 
+    //int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)       // dwe / dbw = (pw+1)
+    //                                 * bin_size_w)) + roi_start_w;    // dwe / drsw = 1 
+    //int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)       // dhe / dbh = (ph+1)
+    //                                 * bin_size_h)) + roi_start_h;    // dhe / drsh = 1
+    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)        // dws / dbw = pw
+                                        * bin_size_w + roi_start_w)); // dws / drsw = 1
+    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)        // dhs / dbh = ph
+                                        * bin_size_h + roi_start_h)); // dhs / drsh = 1
     int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)       // dwe / dbw = (pw+1)
-                                     * bin_size_w)) + roi_start_w;    // dwe / drsw = 1 
+                                     * bin_size_w + roi_start_w));    // dwe / drsw = 1
     int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)       // dhe / dbh = (ph+1)
-                                     * bin_size_h)) + roi_start_h;    // dhe / drsh = 1 
+                                     * bin_size_h + roi_start_h));    // dhe / drsh = 1 
     // dws / dcx = dws / dbw * dbw / dcx + dws / drsw * drsw / dcx = pw * 0 + 1 * spatial_scale * src_w     = spatial_scale * src_w
     // dwe / dcx = dwe / dbw * dbw / dcx + dwe / drsw * drsw / dcx = (pw+1) * 0 + 1 * spatial_scale * src_w = spatial_scale * src_w
 
@@ -111,6 +117,11 @@ __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
 
     // dhs / dsy = dhs / dbh * dbh / dsy + dhs / drsh * drsh / dsy = ph * 1 / pooled_height * spatial_scale * src_h * exp(dsy) + 1 * (-0.5) * spatial_scale * src_h * exp(dsy) = (ph / pooled_height - 0.5) * spatial_scale * src_h * exp(dsy) 
     // dhe / dsy = dhe / dbh * dbh / dsy + dhe / drsh * drsh / dsy = (ph+1) * 1 / pooled_height * spatial_scale * src_h * exp(dsy) + 1 * 0.5 * spatial_scale * src_h * exp(dsy) = ((ph+1)/pooled_height + 0.5) * spatial_scale * src_h * exp(dsy)  
+
+    //top_data[index] = static_cast<Dtype>(hend-1-hstart)+1;
+    //top_data[index] = hend;
+    //top_data[index] = wend; //hend;
+    //top_data[index] = wstart+1; //hstart+1;
 
     Dtype wctr = static_cast<Dtype>(wend-1+wstart) * 0.5;    // dwctr / dwe = 0.5; dwctr / dws = 0.5 
     Dtype hctr = static_cast<Dtype>(hend-1+hstart) * 0.5;    // dhctr / dhe = 0.5; dhctr / dhs = 0.5 
@@ -135,42 +146,48 @@ __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
     hend = min(max(hend, 0), height);
     wstart = min(max(wstart, 0), width);
     wend = min(max(wend, 0), width);
-    //bool is_empty = (hend <= hstart) || (wend <= wstart);
 
     // Define an empty pooling region to be zero
-    //Dtype maxval = is_empty ? 0 : -FLT_MAX;
-    Dtype val = 0; Dtype gain = 0, gain_x = 0, gain_y = 0;   
-    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
-    //int maxidx = -1;
+    Dtype val = 0; Dtype gain = 0, gain_x = 0, gain_y = 0, gain_x_all = 0, gain_y_all = 0;   
     bottom_data += (roi_batch_ind * channels + c) * height * width;
     for (int h = hstart; h < hend; ++h) {
       for (int w = wstart; w < wend; ++w) {
         int bottom_index = h * width + w;
         Dtype w_ = w, h_ = h;  
-        //if (bottom_data[bottom_index] > maxval) {
-        //  maxval = bottom_data[bottom_index];
-        //  maxidx = bottom_index;
-        //}
         //gain_x = max(0., 1 - abs( dst_ctr_x + static_cast<Dtype>(pw) / static_cast<Dtype>(pooled_width) * dst_scl_x - w ));
         //gain_y = max(0., 1 - abs( dst_ctr_y + static_cast<Dtype>(ph) / static_cast<Dtype>(pooled_height) * dst_scl_y - h));
-        gain_x = (wdiff - abs((w_ - wctr))) / wdiff;
-        gain_y = (hdiff - abs((h_ - hctr))) / hdiff; 
+        gain_x = (wdiff - abs((w_ - wctr))) / wdiff; 
+        gain_y = (hdiff - abs((h_ - hctr))) / hdiff;   
         gain = gain_x * gain_y;
-        //val = val + gain * bottom_data[bottom_index];
-        //val = val + bottom_data[bottom_index];
-        val = val + gain;
+
+        val = val + gain * bottom_data[bottom_index];
+        //val = val + gain;
+        if (h == hstart) 
+          gain_x_all = gain_x_all + gain_x;
       }
+      gain_y_all = gain_y_all + gain_y;
     }
-    //top_data[index] = maxval;
-    //argmax_data[index] = maxidx;
-    //top_data[index] = val;
-    top_data[index] = ph; //static_cast<int>(floor(static_cast<Dtype>(ph) * bin_size_h)) + roi_start_h; 
+    if (gain_x_all > 1e-10)
+      val = val / gain_x_all;
+    if (gain_y_all > 1e-10)  
+      val = val / gain_y_all;
+    top_data[index] = val;
+
+    //top_data[index] = gain_x_all; 
+    //top_data[index] = gain_y_all; 
+    int buffer_index = n * (channels * pooled_height * pooled_width * 6) + c * (pooled_height * pooled_width * 6) + ph * (pooled_width * 6) + pw * 6;
+    top_data_buffer[buffer_index+0] = wctr;
+    top_data_buffer[buffer_index+1] = wdiff;
+    top_data_buffer[buffer_index+2] = hctr;
+    top_data_buffer[buffer_index+3] = hdiff; 
+    top_data_buffer[buffer_index+4] = gain_x_all; 
+    top_data_buffer[buffer_index+5] = gain_y_all; 
   }
 }
 
 extern "C"
 void inn_ROIWarping_updateOutput(THCState *state,
-    THCudaTensor *output, /*THCudaTensor *indices,*/
+    THCudaTensor *output, THCudaTensor *output_buffer,
     THCudaTensor *data, THCudaTensor* rois, THCudaTensor* delta_rois, int W, int H, double spatial_scale)
 {
   THAssert(THCudaTensor_nDimension(state, data) == 4);
@@ -185,7 +202,8 @@ void inn_ROIWarping_updateOutput(THCState *state,
   long num_rois = rois->size[0];
   long nInputPlane = data->size[1];
   THCudaTensor_resize4d(state, output, num_rois, nInputPlane, H, W);
-  //THCudaTensor_resize4d(state, indices, num_rois, nInputPlane, H, W);
+  THCudaTensor_resize5d(state, output_buffer, num_rois, nInputPlane, H, W, 6);
+  //THCudaTensor_zero(state, output_buffer);
 
   long count = THCudaTensor_nElement(state, output);
 
@@ -195,8 +213,8 @@ void inn_ROIWarping_updateOutput(THCState *state,
       spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
       THCudaTensor_data(state, rois),
       THCudaTensor_data(state, delta_rois),
-      THCudaTensor_data(state, output) /*,
-      (int*)THCudaTensor_data(state, indices)*/
+      THCudaTensor_data(state, output),
+      THCudaTensor_data(state, output_buffer)
       );
 
   // check for errors
@@ -207,52 +225,126 @@ void inn_ROIWarping_updateOutput(THCState *state,
   }
 }
 
-//template <typename Dtype>
-//__global__ void ROIWarpBackwardAtomic(const int nthreads, const Dtype* top_diff,
-//    /*const int* argmax_data,*/ const int num_rois, const Dtype spatial_scale,
-//    const int channels, const int height, const int width,
-//    const int pooled_height, const int pooled_width, Dtype* bottom_diff,
-//    const Dtype* bottom_rois) {
-//  CUDA_KERNEL_LOOP(index, nthreads) {
-//    // (n, c, ph, pw) is an element in the pooled output
-//    int pw = index % pooled_width;
-//    int ph = (index / pooled_width) % pooled_height;
-//    int c = (index / pooled_width / pooled_height) % channels;
-//    int n = index / pooled_width / pooled_height / channels;
-//
-//    bottom_rois += n * 5;
-//    int roi_batch_ind = (bottom_rois[0] - 1);
-//    int bottom_offset = (roi_batch_ind * channels + c) * height * width;
-//    int top_offset    = (n * channels + c) * pooled_height * pooled_width;
-//    const Dtype* offset_top_diff = top_diff + top_offset;
-//    Dtype* offset_bottom_diff = bottom_diff + bottom_offset;
-//    //const int* offset_argmax_data = argmax_data + top_offset;
-//
-//    //int argmax = offset_argmax_data[ph*pooled_width + pw];
-//    //if(argmax != -1) {
-//    //  atomicAdd(offset_bottom_diff + argmax, offset_top_diff[ph * pooled_width + pw]);
-//    //}
-//  }
-//}
-
 template <typename Dtype>
-__global__ void ROIWarpBackward(const int nthreads, /*const Dtype* bottom_data,*/
+__global__ void ROIWarpBackwardData(const int nthreads, const Dtype* top_data_buffer,
     const Dtype spatial_scale, const int channels, const int height, const int width, 
-    const int pooled_height, const int pooled_width,
+    const int pooled_height, const int pooled_width, const int nth_roi, 
     const Dtype* bottom_rois, const Dtype* bottom_delta_rois, 
     const Dtype* top_diff,
     Dtype* bottom_diff_data, 
-    Dtype* bottom_diff_delta_rois_buffer/*,
-    Dtype* bottom_diff_delta_rois_cx,
-    Dtype* bottom_diff_delta_rois_cy,
-    Dtype* bottom_diff_delta_rois_sx,
-    Dtype* bottom_diff_delta_rois_sy*/) {
+    Dtype* bottom_diff_delta_rois_buffer) {
   CUDA_KERNEL_LOOP(index, nthreads) {
+
+    // (n, c, h, w) is an element in the pooled output
+    int w = index % width;
+    int h = (index / width) % height;
+    int c = (index / width / height) % channels;
+    int n = index / width / height / channels;
+
+    bottom_rois += nth_roi * 5;
+    int roi_batch_ind = (bottom_rois[0] - 1);
+ 
+    if (roi_batch_ind == n) {
+
+      Dtype src_w = bottom_rois[3] - bottom_rois[1] + 1;
+      Dtype src_h = bottom_rois[4] - bottom_rois[2] + 1;
+      Dtype src_ctr_x = bottom_rois[1] + 0.5*(src_w-1.0);
+      Dtype src_ctr_y = bottom_rois[2] + 0.5*(src_h-1.0);
+  
+      Dtype dst_ctr_x = bottom_delta_rois[1]; // dx (in fast-rcnn notation) = cx (in here)
+      Dtype dst_ctr_y = bottom_delta_rois[2]; // dy (in fast-rcnn notation) = cy (in here)
+      Dtype dst_scl_x = bottom_delta_rois[3]; // dw (in fast-rcnn notation) = sx (in here)
+      Dtype dst_scl_y = bottom_delta_rois[4]; // dh (in fast-rcnn notation) = sy (in here)
+  
+      Dtype pred_ctr_x = dst_ctr_x * src_w + src_ctr_x; // dpcx / dcx = src_w
+      Dtype pred_ctr_y = dst_ctr_y * src_h + src_ctr_y; // dpcy / dcy = src_h
+      Dtype pred_w = exp(dst_scl_x) * src_w;            // dpw  / dsx = src_w * exp(dsx)
+      Dtype pred_h = exp(dst_scl_y) * src_h;            // dph  / dsy = src_h * exp(dsy)
+  
+      Dtype roi_start_w = ( (pred_ctr_x - 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drsw / dpcx = spatial_scale; drsw / dpw = -0.5 * spatial_scale
+      Dtype roi_start_h = ( (pred_ctr_y - 0.5*(pred_h-1)) - 1 ) * spatial_scale; // drsh / dpcy = spatial_scale; drsh / dph = -0.5 * spatial_scale
+      Dtype roi_end_w =   ( (pred_ctr_x + 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drew / dpcx = spatial_scale; drew / dpw =  0.5 * spatial_scale
+      Dtype roi_end_h =   ( (pred_ctr_y + 0.5*(pred_h-1)) - 1 ) * spatial_scale; // dreh / dpcy = spatial_scale; dreh / dph =  0.5 * spatial_scale
+      assert(roi_end_w - roi_start_w >= 0);
+      assert(roi_end_h - roi_start_h >= 0);
+  
+      Dtype roi_width  = roi_end_w - roi_start_w + 1;
+      Dtype roi_height = roi_end_h - roi_start_h + 1;
+  
+      Dtype bin_size_pw = static_cast<Dtype>(pooled_width)  / roi_width;  
+      Dtype bin_size_ph = static_cast<Dtype>(pooled_height) / roi_height; 
+  
+      int pwstart = static_cast<int>(floor(static_cast<Dtype>(-roi_start_w + w) 
+                                          * bin_size_pw)); 
+      int phstart = static_cast<int>(floor(static_cast<Dtype>(-roi_start_h + h)
+                                          * bin_size_ph)); 
+      int pwend = static_cast<int>(ceil(static_cast<Dtype>(-roi_start_w + w + 1) 
+                                       * bin_size_pw));
+      int phend = static_cast<int>(ceil(static_cast<Dtype>(-roi_start_h + h + 1)  
+                                       * bin_size_ph)); 
+   
+      //bottom_diff_data[index] = pwend; //phend; 
+      //bottom_diff_data[index] = pwstart+1; //phend; 
+  
+      // Clip to top boundaries
+      phstart = min(max(phstart, 0), pooled_height);         
+      phend =   min(max(phend, 0),   pooled_height);
+      pwstart = min(max(pwstart, 0), pooled_width);
+      pwend =   min(max(pwend, 0),   pooled_width);
+  
+      Dtype w_ = w, h_ = h; 
+      Dtype wctr = 0, wdiff = 0, hctr = 0, hdiff = 0;
+      Dtype gain = 0, gain_x = 0, gain_y = 0, gain_x_all = 0, gain_y_all = 0;  
+      for (int ph = phstart; ph < phend; ++ph) {
+        for (int pw = pwstart; pw < pwend; ++pw) {
+          int top_index = nth_roi * (channels * pooled_height * pooled_width) + c * (pooled_height * pooled_width) + ph * pooled_width  + pw;
+          int top_buffer_index = nth_roi * (channels * pooled_height * pooled_width * 6) + c * (pooled_height * pooled_width * 6) + ph * (pooled_width * 6) + pw * 6;
+          wctr       = top_data_buffer[top_buffer_index+0]; 
+          wdiff      = top_data_buffer[top_buffer_index+1]; 
+          hctr       = top_data_buffer[top_buffer_index+2]; 
+          hdiff      = top_data_buffer[top_buffer_index+3]; 
+          gain_x_all = top_data_buffer[top_buffer_index+4]; 
+          gain_y_all = top_data_buffer[top_buffer_index+5]; 
+  
+          gain_x = (wdiff - abs((w_ - wctr))) / wdiff;   // dgx / dwdiff =   (w-wctr) / (wdiff)^2 ( if w >= wctr )
+                                                         // dgx / dwdiff = - (w-wctr) / (wdiff)^2 ( else )
+                                                         // dgx / dwctr  =   1 / wdiff ( if w >= wctr )
+                                                         // dgx / dwctr  = - 1 / wdiff ( else )
+          gain_y = (hdiff - abs((h_ - hctr))) / hdiff;   // dgy / dhdiff =   (h-hctr) / (hdiff)^2 ( if h >= hctr )
+                                                                                                // dgy / dhdiff = - (h-hctr) / (hdiff)^2 ( else )
+                                                                                                // dgy / dhctr  =   1 / hdiff ( if h >= hctr )
+                                                                                                // dgy / dhdiff = - 1 / hdiff ( else )
+          if (gain_x_all > 1e-10) 
+            gain_x = gain_x / gain_x_all; 
+          if (gain_y_all > 1e-10)  
+            gain_y = gain_y / gain_y_all; 
+  
+          gain = gain_x * gain_y;
+          bottom_diff_data[index] = bottom_diff_data[index] + gain * top_diff[top_index]; //val = val + gain * bottom_data[bottom_index];
+        }
+      }
+    }
+  }
+}
+
+template <typename Dtype>
+__global__ void ROIWarpBackwardDeltaROI(const int nthreads, const Dtype* top_data_buffer,
+    const Dtype spatial_scale, const int channels, const int height, const int width,
+    const int pooled_height, const int pooled_width, 
+    const Dtype* bottom_rois, const Dtype* bottom_delta_rois,
+    const Dtype* top_diff,
+    Dtype* bottom_diff_data,
+    Dtype* bottom_diff_delta_rois_buffer) {
+  CUDA_KERNEL_LOOP(index, nthreads) { 
     // (n, c, ph, pw) is an element in the pooled output
     int pw = index % pooled_width;
     int ph = (index / pooled_width) % pooled_height;
     int c = (index / pooled_width / pooled_height) % channels;
     int n = index / pooled_width / pooled_height / channels;
+
+    int buffer_index = n * (channels * pooled_height * pooled_width * 6) + c * (pooled_height * pooled_width * 6) + ph * (pooled_width * 6) + pw * 6;
+    Dtype gain_x_all = top_data_buffer[buffer_index+4];
+    Dtype gain_y_all = top_data_buffer[buffer_index+5];
 
     bottom_rois += n * 5;
     int roi_batch_ind = (bottom_rois[0] - 1);
@@ -272,10 +364,10 @@ __global__ void ROIWarpBackward(const int nthreads, /*const Dtype* bottom_data,*
     Dtype pred_w = exp(dst_scl_x) * src_w;            // dpw  / dsx = src_w * exp(dsx)  
     Dtype pred_h = exp(dst_scl_y) * src_h;            // dph  / dsy = src_h * exp(dsy)  
     
-    int roi_start_w = ( round(pred_ctr_x - 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drsw / dpcx = spatial_scale; drsw / dpw = -0.5 * spatial_scale
-    int roi_start_h = ( round(pred_ctr_y - 0.5*(pred_h-1)) - 1 ) * spatial_scale; // drsh / dpcy = spatial_scale; drsh / dph = -0.5 * spatial_scale
-    int roi_end_w =   ( round(pred_ctr_x + 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drew / dpcx = spatial_scale; drew / dpw =  0.5 * spatial_scale
-    int roi_end_h =   ( round(pred_ctr_y + 0.5*(pred_h-1)) - 1 ) * spatial_scale; // dreh / dpcy = spatial_scale; dreh / dph =  0.5 * spatial_scale
+    Dtype roi_start_w = ( (pred_ctr_x - 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drsw / dpcx = spatial_scale; drsw / dpw = -0.5 * spatial_scale
+    Dtype roi_start_h = ( (pred_ctr_y - 0.5*(pred_h-1)) - 1 ) * spatial_scale; // drsh / dpcy = spatial_scale; drsh / dph = -0.5 * spatial_scale
+    Dtype roi_end_w =   ( (pred_ctr_x + 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drew / dpcx = spatial_scale; drew / dpw =  0.5 * spatial_scale
+    Dtype roi_end_h =   ( (pred_ctr_y + 0.5*(pred_h-1)) - 1 ) * spatial_scale; // dreh / dpcy = spatial_scale; dreh / dph =  0.5 * spatial_scale
     assert(roi_end_w - roi_start_w >= 0); 
     assert(roi_end_h - roi_start_h >= 0); 
     
@@ -292,19 +384,17 @@ __global__ void ROIWarpBackward(const int nthreads, /*const Dtype* bottom_data,*
     // dreh / dsy = dreh / dph * dph / dsy =  0.5 * spatial_scale * src_h * exp(dsy) 
  
     // Force malformed ROIs to be 1x1
-    int roi_width  = roi_end_w - roi_start_w + 1;   // drw / drew = (rew - rsw) > 0 ?  1 : 0 
-                                                    // drw / drsw = (rew - rsw) > 0 ? -1 : 0
-    int roi_height = roi_end_h - roi_start_h + 1;   // drh / dreh = (reh - rsh) > 0 ?  1 : 0
-                                                    // drh / drsh = (reh - rsh) > 0 ? -1 : 0
+    Dtype roi_width  = roi_end_w - roi_start_w + 1; // drw / drew =  1 
+                                                    // drw / drsw = -1
+    Dtype roi_height = roi_end_h - roi_start_h + 1; // drh / dreh =  1 
+                                                    // drh / drsh = -1 
     // drw / dcx = drw / drew * drew / dcx + drw / drsw * drsw / dcx = drew / dcx - drsw / dcx = spatial_scale * src_w - spatial_scale * src_w = 0 
     // drh / dcy = drh / dreh * dreh / dcy + drh / drsh * drsh / dcy = dreh / dcy - drsh / dcy = spatial_scale * src_h - spatial_scale * src_h = 0 
     // drw / dsx = drw / drew * drew / dsx + drw / drsw * drsw / dsx = drew / dsx - drsw / dsx = 0.5 * spatial_scale * src_w * exp(dsx) - (-0.5 * spatial_scale * src_w * exp(dsx)) = spatial_scale * src_w * exp(dsx) 
     // drh / dsy = drh / dreh * dreh / dsy + drh / drsh * drsh / dsy = dreh / dsy - drsh / dsy = 0.5 * spatial_scale * src_h * exp(dsy) - (-0.5 * spatial_scale * src_h * exp(dsy)) = spatial_scale * src_h * exp(dsy) 
 
-    Dtype bin_size_w = static_cast<Dtype>(roi_width)
-                       / static_cast<Dtype>(pooled_width);  // dbw / drw  =  1 / pooled_width
-    Dtype bin_size_h = static_cast<Dtype>(roi_height)         
-                       / static_cast<Dtype>(pooled_height); // dbh / drh  =  1 / pooled_height
+    Dtype bin_size_w = roi_width  / static_cast<Dtype>(pooled_width);  // dbw / drw  =  1 / pooled_width
+    Dtype bin_size_h = roi_height / static_cast<Dtype>(pooled_height); // dbh / drh  =  1 / pooled_height
     // dbw / dcx = dbw / drw * drw / dcx = 0 
     // dbh / dcy = dbh / drh * drh / dcy = 0
     // dbw / dsx = dbw / drw * drw / dsx = 1 / pooled_width * spatial_scale * src_w * exp(dsx) 
@@ -390,9 +480,10 @@ __global__ void ROIWarpBackward(const int nthreads, /*const Dtype* bottom_data,*
                                                                                               // dgy / dhdiff = - (h-hctr) / (hdiff)^2 ( else )
                                                                                               // dgy / dhctr  =   1 / hdiff ( if h >= hctr )
                                                                                               // dgy / dhdiff = - 1 / hdiff ( else )
-        gain = gain_x * gain_y;
-        //bottom_diff_data[bottom_index] = bottom_diff_data[bottom_index] + gain * top_diff[index]; //val = val + gain * bottom_data[bottom_index];
-        bottom_diff_data[bottom_index] = ph; //static_cast<int>(floor(static_cast<Dtype>(ph) * bin_size_h)) + roi_start_h;
+        if (gain_x_all > 1e-10)
+          gain_x = gain_x / gain_x_all;
+        if (gain_y_all > 1e-10)
+          gain_y = gain_y / gain_y_all;
 
         // buffer 
         Dtype coeff_x = w >= wctr ? 1 : -1; coeff_x = coeff_x * gain_y * spatial_scale * src_w_ * top_diff[index]; 
@@ -409,7 +500,7 @@ __global__ void ROIWarpBackward(const int nthreads, /*const Dtype* bottom_data,*
                                                  //                    =        gain_y * dgain_x/ddelta_rois +        gain_x * dgain_y/ddelta_rois
       }
     }
-    int buffer_index = n * (channels * pooled_height * pooled_width * 4) + c * (pooled_height * pooled_width * 4) + ph * (pooled_width * 4) + pw * 4; 
+    /*int*/ buffer_index = n * (channels * pooled_height * pooled_width * 4) + c * (pooled_height * pooled_width * 4) + ph * (pooled_width * 4) + pw * 4; 
     bottom_diff_delta_rois_buffer[buffer_index+0] = val_cx; 
     bottom_diff_delta_rois_buffer[buffer_index+1] = val_cy; 
     bottom_diff_delta_rois_buffer[buffer_index+2] = val_sx;
@@ -424,18 +515,21 @@ __global__ void ROIWarpBackward(const int nthreads, /*const Dtype* bottom_data,*
 
 extern "C"
 void inn_ROIWarping_updateGradInputAtomic(THCState *state,
-    THCudaTensor *gradInput_data, THCudaTensor *data,
+    THCudaTensor *gradInput_data, THCudaTensor *data,   
     THCudaTensor *gradInput_delta_rois, THCudaTensor *delta_rois,
     THCudaTensor *gradInput_delta_rois_buffer,
-    THCudaTensor *gradOutput, THCudaTensor* rois, int W, int H, double spatial_scale)
+    THCudaTensor *gradOutput, THCudaTensor *top_data_buffer, 
+    THCudaTensor* rois, int W, int H, double spatial_scale)
 {
   THAssert(THCudaTensor_nDimension(state, data) == 4);
+  THAssert(THCudaTensor_nDimension(state, top_data_buffer) == 5);
   THAssert(THCudaTensor_nDimension(state, rois) == 2 && rois->size[1] == 5);
   THAssert(THCudaTensor_nDimension(state, delta_rois) == 2 && delta_rois->size[1] == 5);
   THAssert(THCudaTensor_nDimension(state, rois) == THCudaTensor_nDimension(state, delta_rois) &&
            rois->size[0] == delta_rois->size[0] &&
            rois->size[1] == delta_rois->size[1]);
   THAssert(THCudaTensor_isContiguous(state, data));
+  THAssert(THCudaTensor_isContiguous(state, top_data_buffer));
   THAssert(THCudaTensor_isContiguous(state, rois));
   THAssert(THCudaTensor_isContiguous(state, delta_rois));
   long num_rois = rois->size[0];
@@ -444,41 +538,35 @@ void inn_ROIWarping_updateGradInputAtomic(THCState *state,
   THCudaTensor_zero(state, gradInput_data);
   THCudaTensor_resizeAs(state, gradInput_delta_rois, delta_rois);
   THCudaTensor_zero(state, gradInput_delta_rois);
-
   THCudaTensor_resize5d(state, gradInput_delta_rois_buffer, num_rois, nInputPlane, H, W, 4);
   THCudaTensor_zero(state, gradInput_delta_rois_buffer);
-  //THCudaTensor_resizeAs(state, gradInput_delta_rois_dx, gradOutput);
-  //THCudaTensor_zero(state, gradInput_delta_rois_dx);
-  //THCudaTensor_resizeAs(state, gradInput_delta_rois_dy, gradOutput);
-  //THCudaTensor_zero(state, gradInput_delta_rois_dy);
-  //THCudaTensor_resizeAs(state, gradInput_delta_rois_dw, gradOutput);
-  //THCudaTensor_zero(state, gradInput_delta_rois_dw);
-  //THCudaTensor_resizeAs(state, gradInput_delta_rois_dh, gradOutput);
-  //THCudaTensor_zero(state, gradInput_delta_rois_dh);
 
-  long count = THCudaTensor_nElement(state, gradOutput);
+  //Backpropagation for data
+  long count = THCudaTensor_nElement(state, gradInput_data);
+  for (int nth_roi = 0; nth_roi < num_rois; ++nth_roi) {
+    ROIWarpBackwardData<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS / 2, 0, THCState_getCurrentStream(state)>>>(
+        count,
+        THCudaTensor_data(state, top_data_buffer),
+        spatial_scale, nInputPlane, data->size[2], data->size[3], H, W, nth_roi,
+        THCudaTensor_data(state, rois),
+        THCudaTensor_data(state, delta_rois),
+        THCudaTensor_data(state, gradOutput), 
+        THCudaTensor_data(state, gradInput_data),
+        THCudaTensor_data(state, gradInput_delta_rois_buffer)
+        );
+  }
 
-  //ROIWarpBackwardAtomic<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
-  //    count,
-  //    THCudaTensor_data(state, gradOutput),
-  //    //(int*)THCudaTensor_data(state, indices),
-  //    num_rois, spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
-  //    THCudaTensor_data(state, gradInput_data),
-  //    THCudaTensor_data(state, rois)
-  //    );
-  ROIWarpBackward<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS / 2, 0, THCState_getCurrentStream(state)>>>(
+  //Backpropagation for delta_roi
+  count = THCudaTensor_nElement(state, gradOutput);
+  ROIWarpBackwardDeltaROI<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS / 2, 0, THCState_getCurrentStream(state)>>>(
       count,
-      //THCudaTensor_data(state, data),
-      spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
+      THCudaTensor_data(state, top_data_buffer),
+      spatial_scale, nInputPlane, data->size[2], data->size[3], H, W, 
       THCudaTensor_data(state, rois),
       THCudaTensor_data(state, delta_rois),
-      THCudaTensor_data(state, gradOutput), 
+      THCudaTensor_data(state, gradOutput),
       THCudaTensor_data(state, gradInput_data),
-      THCudaTensor_data(state, gradInput_delta_rois_buffer)/*,
-      THCudaTensor_data(state, gradInput_delta_rois_dx),
-      THCudaTensor_data(state, gradInput_delta_rois_dy),
-      THCudaTensor_data(state, gradInput_delta_rois_dw),
-      THCudaTensor_data(state, gradInput_delta_rois_dh)*/
+      THCudaTensor_data(state, gradInput_delta_rois_buffer)
       );
 
   // check for errors

--- a/ROIWarping.cu
+++ b/ROIWarping.cu
@@ -23,7 +23,7 @@ template <typename Dtype>
 __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
     const Dtype spatial_scale, const int channels, const int height,
     const int width, const int pooled_height, const int pooled_width,
-    const Dtype* bottom_rois, const Dtype* bottom_delta_rois, Dtype* top_data, int* argmax_data) {
+    const Dtype* bottom_rois, const Dtype* bottom_delta_rois, Dtype* top_data/*, int* argmax_data*/) {
   CUDA_KERNEL_LOOP(index, nthreads) {
     // (n, c, ph, pw) is an element in the pooled output
     int pw = index % pooled_width;
@@ -118,7 +118,7 @@ __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
 
 extern "C"
 void inn_ROIWarping_updateOutput(THCState *state,
-    THCudaTensor *output, THCudaTensor *indices,
+    THCudaTensor *output, /*THCudaTensor *indices,*/
     THCudaTensor *data, THCudaTensor* rois, THCudaTensor* delta_rois, int W, int H, double spatial_scale)
 {
   THAssert(THCudaTensor_nDimension(state, data) == 4);
@@ -133,7 +133,7 @@ void inn_ROIWarping_updateOutput(THCState *state,
   long num_rois = rois->size[0];
   long nInputPlane = data->size[1];
   THCudaTensor_resize4d(state, output, num_rois, nInputPlane, H, W);
-  THCudaTensor_resize4d(state, indices, num_rois, nInputPlane, H, W);
+  //THCudaTensor_resize4d(state, indices, num_rois, nInputPlane, H, W);
 
   long count = THCudaTensor_nElement(state, output);
 
@@ -143,8 +143,8 @@ void inn_ROIWarping_updateOutput(THCState *state,
       spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
       THCudaTensor_data(state, rois),
       THCudaTensor_data(state, delta_rois),
-      THCudaTensor_data(state, output),
-      (int*)THCudaTensor_data(state, indices)
+      THCudaTensor_data(state, output) /*,
+      (int*)THCudaTensor_data(state, indices)*/
       );
 
   // check for errors

--- a/ROIWarping.cu
+++ b/ROIWarping.cu
@@ -174,8 +174,8 @@ __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
         Dtype w_ = w;  
         //gain_x = max(0., 1 - abs( dst_ctr_x + static_cast<Dtype>(pw) / static_cast<Dtype>(pooled_width) * dst_scl_x - w ));
         //gain_y = max(0., 1 - abs( dst_ctr_y + static_cast<Dtype>(ph) / static_cast<Dtype>(pooled_height) * dst_scl_y - h));
-        gain_x = (wdiff - abs((w_ - wctr))) / wdiff; 
-        gain_y = (hdiff - abs((h_ - hctr))) / hdiff;   
+        gain_x = wdiff - abs((w_ - wctr)); 
+        gain_y = hdiff - abs((h_ - hctr));   
         gain = gain_x * gain_y;
 
         val = val + gain * bottom_data[bottom_index];
@@ -187,15 +187,15 @@ __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
 
           // Update information used in backprop
           w_mask = w_ >= wctr ? 1 : -1;
-          dgx_final_dwctr_all  = dgx_final_dwctr_all  + w_mask * 1 / wdiff;
-          dgx_final_dwdiff_all = dgx_final_dwdiff_all + w_mask * (w_-wctr) / (wdiff*wdiff);
+          dgx_final_dwctr_all  = dgx_final_dwctr_all  + w_mask;
+          dgx_final_dwdiff_all = dgx_final_dwdiff_all + 1;
         }
       }
       gain_y_all = gain_y_all + gain_y;
         
       h_mask = h >= hctr ? 1 : -1;
-      dgy_final_dhctr_all  = dgy_final_dhctr_all  + h_mask * 1 / hdiff;
-      dgy_final_dhdiff_all = dgy_final_dhdiff_all + h_mask * (h_-hctr) / (hdiff*hdiff);
+      dgy_final_dhctr_all  = dgy_final_dhctr_all  + h_mask;
+      dgy_final_dhdiff_all = dgy_final_dhdiff_all + 1;
     }
     if (gain_x_all > 1e-10)
       val = val / gain_x_all;
@@ -339,14 +339,12 @@ __global__ void ROIWarpBackwardData(const int nthreads, const Dtype* top_data_bu
           gain_x_all = top_data_buffer[top_buffer_index+4]; 
           gain_y_all = top_data_buffer[top_buffer_index+5]; 
   
-          gain_x = (wdiff - abs((w_ - wctr))) / wdiff;   // dgx / dwdiff =   (w-wctr) / (wdiff)^2 ( if w >= wctr )
-                                                         // dgx / dwdiff = - (w-wctr) / (wdiff)^2 ( else )
-                                                         // dgx / dwctr  =   1 / wdiff ( if w >= wctr )
-                                                         // dgx / dwctr  = - 1 / wdiff ( else )
-          gain_y = (hdiff - abs((h_ - hctr))) / hdiff;   // dgy / dhdiff =   (h-hctr) / (hdiff)^2 ( if h >= hctr )
-                                                                                                // dgy / dhdiff = - (h-hctr) / (hdiff)^2 ( else )
-                                                                                                // dgy / dhctr  =   1 / hdiff ( if h >= hctr )
-                                                                                                // dgy / dhdiff = - 1 / hdiff ( else )
+          gain_x = wdiff - abs((w_ - wctr));   // dgx / dwdiff =   1  
+                                               // dgx / dwctr  =   1 ( if w >= wctr )
+                                               // dgx / dwctr  = - 1 ( else )
+          gain_y = hdiff - abs((h_ - hctr));   // dgy / dhdiff =   1
+                                               // dgy / dhctr  =   1 ( if h >= hctr )
+                                               // dgy / dhctr  = - 1 ( else )
           if (gain_x_all > 1e-10) 
             gain_x = gain_x / gain_x_all; 
           if (gain_y_all > 1e-10)  
@@ -407,13 +405,13 @@ __global__ void ROIWarpBackwardDeltaROI(const int nthreads, const Dtype* top_dat
       Dtype pred_w = exp(dst_scl_x) * src_w;            // dpw  / dsx = src_w * exp(dsx)  
       Dtype pred_h = exp(dst_scl_y) * src_h;            // dph  / dsy = src_h * exp(dsy)  
       
-      Dtype roi_start_w = ( (pred_ctr_x - 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drsw / dpcx = spatial_scale; 
+      Dtype roi_start_w = ( (pred_ctr_x - 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drsw / dpcx =       spatial_scale 
                                                                                  // drsw / dpw = -0.5 * spatial_scale
-      Dtype roi_start_h = ( (pred_ctr_y - 0.5*(pred_h-1)) - 1 ) * spatial_scale; // drsh / dpcy = spatial_scale; 
+      Dtype roi_start_h = ( (pred_ctr_y - 0.5*(pred_h-1)) - 1 ) * spatial_scale; // drsh / dpcy =       spatial_scale 
                                                                                  // drsh / dph = -0.5 * spatial_scale
-      Dtype roi_end_w =   ( (pred_ctr_x + 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drew / dpcx = spatial_scale; 
+      Dtype roi_end_w =   ( (pred_ctr_x + 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drew / dpcx =       spatial_scale 
                                                                                  // drew / dpw =  0.5 * spatial_scale
-      Dtype roi_end_h =   ( (pred_ctr_y + 0.5*(pred_h-1)) - 1 ) * spatial_scale; // dreh / dpcy = spatial_scale; 
+      Dtype roi_end_h =   ( (pred_ctr_y + 0.5*(pred_h-1)) - 1 ) * spatial_scale; // dreh / dpcy =       spatial_scale 
                                                                                  // dreh / dph =  0.5 * spatial_scale
       assert(roi_end_w - roi_start_w >= 0); 
       assert(roi_end_h - roi_start_h >= 0); 
@@ -500,26 +498,26 @@ __global__ void ROIWarpBackwardDeltaROI(const int nthreads, const Dtype* top_dat
       // dhdiff / dsy = (1 / pooled_height + 1) * spatial_scale * src_h * exp(dsy) 
 
 
-      // dgx / dwctr  = (w >= wctr ? 1 : -1) * 1 / wdiff 
-      // dgx / dwdiff = (w >= wctr ? 1 : -1) * (w-wctr) / (wdiff)^2
-      // dgy / dhctr  = (h >= hctr ? 1 : -1) * 1 / hdiff 
-      // dgy / dhdiff = (h >= hctr ? 1 : -1) * (h-hctr) / (hdiff)^2 
+      // dgx / dwctr  = (w >= wctr ? 1 : -1)  
+      // dgx / dwdiff = 1 
+      // dgy / dhctr  = (h >= hctr ? 1 : -1)  
+      // dgy / dhdiff = 1
  
       // gx_final = gx / gx_all 
-      // dgx_final / dwctr  = ( dgx/dwctr  * gx_all - gx * dgx_all/dwctr  ) / (gx_all)^2 = ( (w >= wctr ? 1 : -1) * 1        /  wdiff    * gx_all - gx * sum_for_w{ (w >= wctr ? 1 : -1) * 1        / wdiff   } ) / gx_all^2
-      // dgx_final / dwdiff = ( dgx/dwdiff * gx_all - gx * dgx_all/dwdiff ) / (gx_all)^2 = ( (w >= wctr ? 1 : -1) * (w-wctr) / (wdiff)^2 * gx_all - gx * sum_for_w{ (w >= wctr ? 1 : -1) * (w-wctr) / wdiff^2 } ) / gx_all^2
+      // dgx_final / dwctr  = ( dgx/dwctr  * gx_all - gx * dgx_all/dwctr  ) / (gx_all)^2 = ( (w >= wctr ? 1 : -1) * gx_all - gx * sum_for_w{ (w >= wctr ? 1 : -1) } ) / gx_all^2
+      // dgx_final / dwdiff = ( dgx/dwdiff * gx_all - gx * dgx_all/dwdiff ) / (gx_all)^2 = (       1              * gx_all - gx * sum_for_w{          1           } ) / gx_all^2
       // gy_final = gy / gy_all
       // dgy_final / dhctr  = ...
       // dgy_final / dhdiff = ...
 
       // dgx_final / dcx = dgx_final / dwctr * dwctr / dcx + dgx_final / dwdiff * dwdiff / dcx
-      //                 = ( (w >= wctr ? 1 : -1) * 1 / wdiff * gx_all - gx * sum_for_w{ (w >= wctr ? 1 : -1) * 1 / wdiff } ) / gx_all^2 * spatial_scale * src_w + (...) * 0
-      //                 = ( (w >= wctr ? 1 : -1) * 1 / wdiff * gx_all - gx * sum_for_w{ (w >= wctr ? 1 : -1) * 1 / wdiff } ) / gx_all^2 * spatial_scale * src_w 
-      // dgy_final / dcy = ( (h >= hctr ? 1 : -1) * 1 / hdiff * gy_all - gy * sum_for_h{ (h >= hctr ? 1 : -1) * 1 / hdiff } ) / gx_all^2 * spatial_scale * src_h
-      // dgx_final / dsx = ( (w >= wctr ? 1 : -1) * 1 / wdiff * gx_all            - gx * sum_for_w{ (w >= wctr ? 1 : -1) * 1 / wdiff }          ) / gx_all^2 * (pw + 0.5) / pooled_width  * spatial_scale * src_w * exp(dsx) + 
-      //                   ( (w >= wctr ? 1 : -1) * (w-wctr) / (wdiff)^2 * gx_all - gx * sum_for_w{ (w >= wctr ? 1 : -1) * (w-wctr) / wdiff^2 } ) / gx_all^2 * (1 / pooled_width + 1)     * spatial_scale * src_w * exp(dsx) 
-      // dgy_final / dsy = ( (h >= hctr ? 1 : -1) * 1 / hdiff * gy_all            - gy * sum_for_h{ (h >= hctr ? 1 : -1) * 1 / hdiff }          ) / gy_all^2 * (ph + 0.5) / pooled_height * spatial_scale * src_h * exp(dsy) + 
-      //                   ( (h >= hctr ? 1 : -1) * (h-hctr) / (hdiff)^2 * gy_all - gy * sum_for_h{ (h >= hctr ? 1 : -1) * (h-hctr) / hdiff^2 } ) / gy_all^2 * (1 / pooled_height + 1)    * spatial_scale * src_h * exp(dsy) 
+      //                 = ( (w >= wctr ? 1 : -1) * gx_all - gx * sum_for_w{ (w >= wctr ? 1 : -1) } ) / gx_all^2 * spatial_scale * src_w + (...) * 0
+      //                 = ( (w >= wctr ? 1 : -1) * gx_all - gx * sum_for_w{ (w >= wctr ? 1 : -1) } ) / gx_all^2 * spatial_scale * src_w 
+      // dgy_final / dcy = ( (h >= hctr ? 1 : -1) * gy_all - gy * sum_for_h{ (h >= hctr ? 1 : -1) } ) / gx_all^2 * spatial_scale * src_h
+      // dgx_final / dsx = ( (w >= wctr ? 1 : -1) * gx_all - gx * sum_for_w{ (w >= wctr ? 1 : -1) } ) / gx_all^2 * (pw + 0.5) / pooled_width  * spatial_scale * src_w * exp(dsx) + 
+      //                   (           1          * gx_all - gx * sum_for_w{         1            } ) / gx_all^2 * (1 / pooled_width + 1)     * spatial_scale * src_w * exp(dsx) 
+      // dgy_final / dsy = ( (h >= hctr ? 1 : -1) * gy_all - gy * sum_for_h{ (h >= hctr ? 1 : -1) } ) / gy_all^2 * (ph + 0.5) / pooled_height * spatial_scale * src_h * exp(dsy) + 
+      //                   (           1          * gy_all - gy * sum_for_h{         1            } ) / gy_all^2 * (1 / pooled_height + 1)    * spatial_scale * src_h * exp(dsy) 
 
       // dg / dcx = dg / dgx_final * dgx_final / dcx + dg / dgy_final * dgy_final / dcx
       //          =   gy_final     * dgx_final / dcx +   gx_final     * 0
@@ -540,36 +538,35 @@ __global__ void ROIWarpBackwardDeltaROI(const int nthreads, const Dtype* top_dat
       Dtype ph_ = static_cast<Dtype>(ph);
       Dtype pooled_width_  = static_cast<Dtype>(pooled_width); 
       Dtype pooled_height_ = static_cast<Dtype>(pooled_height);
-      //Dtype buffer_sx = 0, buffer_sy = 0;  
       bottom_data += (roi_batch_ind * channels + c) * height * width;
       Dtype w_mask = 0, h_mask = 0, coeff_x = 0, coeff_y = 0; 
       for (int h = hstart; h < hend; ++h) {
         for (int w = wstart; w < wend; ++w) {
           int bottom_index = h * width + w;
           Dtype w_ = w, h_ = h;  
-          gain_x = (wdiff - abs((w_ - wctr))) / wdiff;   
-          gain_y = (hdiff - abs((h_ - hctr))) / hdiff;   
+          gain_x = wdiff - abs((w_ - wctr));   
+          gain_y = hdiff - abs((h_ - hctr));   
 
           w_mask = w_ >= wctr ? 1 : -1;   
           h_mask = h_ >= hctr ? 1 : -1;  
 
-          //val_cx = val_cx + gain_y * (w_mask / wdiff * gain_x_all - gain_x * dgx_final_dwctr_all                     ) / (gain_x_all*gain_x_all)                            * spatial_scale * src_w * top_diff[index]; 
-          //val_cy = val_cy + gain_x * (h_mask / hdiff * gain_y_all - gain_y * dgy_final_dhctr_all                     ) / (gain_y_all*gain_y_all)                            * spatial_scale * src_h * top_diff[index];
-          //val_sx = val_sx + gain_y *((w_mask * (w_-wctr) / (wdiff*wdiff) * gain_x_all - gain_x * dgx_final_dwdiff_all) / (gain_x_all*gain_x_all) * (pw_+0.5) / pooled_width * spatial_scale * src_w * exp(dsx) + 
-          //                           (w_mask / wdiff * gain_x_all - gain_x * dgx_final_dwctr_all                     ) / (gain_x_all*gain_x_all) * (1 / pooled_width + 1)   * spatial_scale * src_w * exp(dsx) ) * top_diff[index]; 
-          //val_sy = val_sy + gain_x *((h_mask * (h_-hctr) / (hdiff*hdiff) * gain_y_all - gain_y * dgy_final_dhdiff_all) / (gain_y_all*gain_y_all) * (ph_+0.5) / pooled_hidth * spatial_scale * src_h * eyp(dsy) +
-          //                           (h_mask / hdiff * gain_y_all - gain_y * dgy_final_dhctr_all                     ) / (gain_y_all*gain_y_all) * (1 / pooled_hidth + 1)   * spatial_scale * src_h * eyp(dsy) ) * top_diff[index];
+          //val_cx = val_cx + gain_y * (w_mask * gain_x_all - gain_x * dgx_final_dwctr_all ) / (gain_x_all*gain_x_all)                            * spatial_scale * src_w * top_diff[index]; 
+          //val_cy = val_cy + gain_x * (h_mask * gain_y_all - gain_y * dgy_final_dhctr_all ) / (gain_y_all*gain_y_all)                            * spatial_scale * src_h * top_diff[index];
+          //val_sx = val_sx + gain_y *((         gain_x_all - gain_x * dgx_final_dwdiff_all) / (gain_x_all*gain_x_all) * (pw_+0.5) / pooled_width * spatial_scale * src_w * exp(dsx) + 
+          //                           (w_mask * gain_x_all - gain_x * dgx_final_dwctr_all ) / (gain_x_all*gain_x_all) * (1 / pooled_width + 1)   * spatial_scale * src_w * exp(dsx) ) * top_diff[index]; 
+          //val_sy = val_sy + gain_x *((         gain_y_all - gain_y * dgy_final_dhdiff_all) / (gain_y_all*gain_y_all) * (ph_+0.5) / pooled_hidth * spatial_scale * src_h * eyp(dsy) +
+          //                           (h_mask * gain_y_all - gain_y * dgy_final_dhctr_all ) / (gain_y_all*gain_y_all) * (1 / pooled_hidth + 1)   * spatial_scale * src_h * eyp(dsy) ) * top_diff[index];
 
           //if (gain_x > 1e-10 && gain_y > 1e-10) {
             coeff_x = bottom_data[bottom_index] * gain_y / gain_y_all * spatial_scale * src_w * top_diff[index] / (gain_x_all*gain_x_all);
-            val_cx = val_cx +  (w_mask / wdiff * gain_x_all - gain_x * dgx_final_dwctr_all                     )                                         * coeff_x;
-            val_sx = val_sx + ((w_mask / wdiff * gain_x_all - gain_x * dgx_final_dwctr_all                     ) * (pw_+0.5) +
-                               (w_mask * (w_-wctr) / (wdiff*wdiff) * gain_x_all - gain_x * dgx_final_dwdiff_all) * (1 + pooled_width_) ) / pooled_width_ * coeff_x * exp(dst_scl_x);
+            val_cx = val_cx +  (w_mask * gain_x_all - gain_x * dgx_final_dwctr_all )                                         * coeff_x;
+            val_sx = val_sx + ((w_mask * gain_x_all - gain_x * dgx_final_dwctr_all ) * (pw_+0.5) +
+                               (         gain_x_all - gain_x * dgx_final_dwdiff_all) * (1 + pooled_width_) ) / pooled_width_ * coeff_x * exp(dst_scl_x);
           
             coeff_y = bottom_data[bottom_index] * gain_x / gain_x_all * spatial_scale * src_h * top_diff[index] / (gain_y_all*gain_y_all);
-            val_cy = val_cy +  (h_mask / hdiff * gain_y_all - gain_y * dgy_final_dhctr_all                     )                                           * coeff_y;
-            val_sy = val_sy + ((h_mask / hdiff * gain_y_all - gain_y * dgy_final_dhctr_all                     ) * (ph_+0.5) + 
-                               (h_mask * (h_-hctr) / (hdiff*hdiff) * gain_y_all - gain_y * dgy_final_dhdiff_all) * (1 + pooled_height_) ) / pooled_height_ * coeff_y * exp(dst_scl_y);
+            val_cy = val_cy +  (h_mask * gain_y_all - gain_y * dgy_final_dhctr_all )                                           * coeff_y;
+            val_sy = val_sy + ((h_mask * gain_y_all - gain_y * dgy_final_dhctr_all ) * (ph_+0.5) + 
+                               (         gain_y_all - gain_y * dgy_final_dhdiff_all) * (1 + pooled_height_) ) / pooled_height_ * coeff_y * exp(dst_scl_y);
           //}
         }
       }

--- a/ROIWarping.cu
+++ b/ROIWarping.cu
@@ -11,6 +11,7 @@
 #include "THC.h"
 #include <algorithm>
 #include <cfloat>
+#include "assert.h"
 
 #include "common.h"
 
@@ -43,50 +44,98 @@ __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
     Dtype src_ctr_x = bottom_rois[1] + 0.5*(src_w-1.0); 
     Dtype src_ctr_y = bottom_rois[2] + 0.5*(src_h-1.0); 
 
-    Dtype dst_ctr_x = bottom_delta_rois[1]; // dx
-    Dtype dst_ctr_y = bottom_delta_rois[2]; // dy
-    Dtype dst_scl_x = bottom_delta_rois[3]; // dw
-    Dtype dst_scl_y = bottom_delta_rois[4]; // dh
+    Dtype dst_ctr_x = bottom_delta_rois[1]; // dx (in fast-rcnn notation) = cx (in here)
+    Dtype dst_ctr_y = bottom_delta_rois[2]; // dy (in fast-rcnn notation) = cy (in here) 
+    Dtype dst_scl_x = bottom_delta_rois[3]; // dw (in fast-rcnn notation) = sx (in here)
+    Dtype dst_scl_y = bottom_delta_rois[4]; // dh (in fast-rcnn notation) = sy (in here) 
 
-    Dtype pred_ctr_x = dst_ctr_x * src_w + src_ctr_x;
-    Dtype pred_ctr_y = dst_ctr_y * src_h + src_ctr_y;
-    Dtype pred_w = exp(dst_scl_x) * src_w;
-    Dtype pred_h = exp(dst_scl_y) * src_h;
+    Dtype pred_ctr_x = dst_ctr_x * src_w + src_ctr_x; // dpcx / dcx = src_w
+    Dtype pred_ctr_y = dst_ctr_y * src_h + src_ctr_y; // dpcy / dcy = src_h
+    Dtype pred_w = exp(dst_scl_x) * src_w;            // dpw  / dsx = src_w * exp(dsx)  
+    Dtype pred_h = exp(dst_scl_y) * src_h;            // dph  / dsy = src_h * exp(dsy)  
+    
+    int roi_start_w = ( round(pred_ctr_x - 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drsw / dpcx = spatial_scale; drsw / dpw = -0.5 * spatial_scale
+    int roi_start_h = ( round(pred_ctr_y - 0.5*(pred_h-1)) - 1 ) * spatial_scale; // drsh / dpcy = spatial_scale; drsh / dph = -0.5 * spatial_scale
+    int roi_end_w =   ( round(pred_ctr_x + 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drew / dpcx = spatial_scale; drew / dpw =  0.5 * spatial_scale
+    int roi_end_h =   ( round(pred_ctr_y + 0.5*(pred_h-1)) - 1 ) * spatial_scale; // dreh / dpcy = spatial_scale; dreh / dph =  0.5 * spatial_scale
+    assert(roi_end_w - roi_start_w >= 0);
+    assert(roi_end_h - roi_start_h >= 0);   
+    
+    // drsw / dcx = drsw / dpcx * dpcx / dcx = spatial_scale * src_w
+    // drew / dcx = drew / dpcx * dpcx / dcx = spatial_scale * src_w
 
-    int roi_start_w = ( max(1., round(pred_ctr_x - 0.5*(pred_w-1)))      - 1 ) * spatial_scale;
-    int roi_start_h = ( max(1., round(pred_ctr_y - 0.5*(pred_h-1)))      - 1 ) * spatial_scale;
-    int roi_end_w =   ( min(static_cast<Dtype>(height), round(pred_ctr_x + 0.5*(pred_w-1))) - 1 ) * spatial_scale;
-    int roi_end_h =   ( min(static_cast<Dtype>(width), round(pred_ctr_y + 0.5*(pred_h-1)))  - 1 ) * spatial_scale; 
+    // drsh / dcy = drsh / dpcy * dpcy / dcy = spatial_scale * src_h
+    // dreh / dcy = dreh / dpcy * dpcy / dcy = spatial_scale * src_h
 
+    // drsw / dsx = drsw / dpw * dpw / dsx = -0.5 * spatial_scale * src_w * exp(dsx) 
+    // drew / dsx = drew / dpw * dpw / dsx =  0.5 * spatial_scale * src_w * exp(dsx)
+ 
+    // drsh / dsy = drsh / dph * dph / dsy = -0.5 * spatial_scale * src_h * exp(dsy)
+    // dreh / dsy = dreh / dph * dph / dsy =  0.5 * spatial_scale * src_h * exp(dsy) 
+ 
     // Force malformed ROIs to be 1x1
-    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
-    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
-    Dtype bin_size_h = static_cast<Dtype>(roi_height)
-                       / static_cast<Dtype>(pooled_height);
+    int roi_width  = roi_end_w - roi_start_w + 1;    // drw / drew = (rew - rsw) > 0 ?  1 : 0 
+                                                    // drw / drsw = (rew - rsw) > 0 ? -1 : 0
+    int roi_height = roi_end_h - roi_start_h + 1;   // drh / dreh = (reh - rsh) > 0 ?  1 : 0
+                                                    // drh / drsh = (reh - rsh) > 0 ? -1 : 0
+    // drw / dcx = drw / drew * drew / dcx + drw / drsw * drsw / dcx = drew / dcx - drsw / dcx = spatial_scale * src_w - spatial_scale * src_w = 0 
+    // drh / dcy = drh / dreh * dreh / dcy + drh / drsh * drsh / dcy = dreh / dcy - drsh / dcy = spatial_scale * src_h - spatial_scale * src_h = 0 
+    // drw / dsx = drw / drew * drew / dsx + drw / drsw * drsw / dsx = drew / dsx - drsw / dsx = 0.5 * spatial_scale * src_w * exp(dsx) - (-0.5 * spatial_scale * src_w * exp(dsx)) = spatial_scale * src_w * exp(dsx) 
+    // drh / dsy = drh / dreh * dreh / dsy + drh / drsh * drsh / dsy = dreh / dsy - drsh / dsy = 0.5 * spatial_scale * src_h * exp(dsy) - (-0.5 * spatial_scale * src_h * exp(dsy)) = spatial_scale * src_h * exp(dsy) 
+    
     Dtype bin_size_w = static_cast<Dtype>(roi_width)
-                       / static_cast<Dtype>(pooled_width);
+                       / static_cast<Dtype>(pooled_width);  // dbw / drw  =  1 / pooled_width
+    Dtype bin_size_h = static_cast<Dtype>(roi_height)         
+                       / static_cast<Dtype>(pooled_height); // dbh / drh  =  1 / pooled_height
+    // dbw / dcx = dbw / drw * drw / dcx = 0 
+    // dbh / dcy = dbh / drh * drh / dcy = 0
+    // dbw / dsx = dbw / drw * drw / dsx = 1 / pooled_width * spatial_scale * src_w * exp(dsx) 
+    // dbh / dsy = dbh / drh * drh / dsy = 1 / pooled_height * spatial_scale * src_h * exp(dsy) 
 
-    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
-                                        * bin_size_h));
-    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)
-                                        * bin_size_w));
-    int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)
-                                     * bin_size_h));
-    int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)
-                                     * bin_size_w));
+    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)        // dws / dbw = pw 
+                                        * bin_size_w)) + roi_start_w; // dws / drsw = 1
+    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)        // dhs / dbh = ph 
+                                        * bin_size_h)) + roi_start_h; // dhs / drsh = 1 
+    int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)       // dwe / dbw = (pw+1)
+                                     * bin_size_w)) + roi_start_w;    // dwe / drsw = 1 
+    int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)       // dhe / dbh = (ph+1)
+                                     * bin_size_h)) + roi_start_h;    // dhe / drsh = 1 
+    // dws / dcx = dws / dbw * dbw / dcx + dws / drsw * drsw / dcx = pw * 0 + 1 * spatial_scale * src_w     = spatial_scale * src_w
+    // dwe / dcx = dwe / dbw * dbw / dcx + dwe / drsw * drsw / dcx = (pw+1) * 0 + 1 * spatial_scale * src_w = spatial_scale * src_w
 
-    Dtype hctr = static_cast<Dtype>(hend-1+hstart)/2.; 
-    Dtype wctr = static_cast<Dtype>(wend-1+wstart)/2.; 
+    // dws / dsx = dws / dbw * dbw / dsx + dws / drsw * drsw / dsx = pw * 1 / pooled_width * spatial_scale * src_w * exp(dsx) + 1 * (-0.5) * spatial_scale * src_w * exp(dsx) = ( pw / pooled_width - 0.5 ) * spatial_scale * src_w * exp(dsx) 
+    // dwe / dsx = dwe / dbw * dbw / dsx + dwe / drsw * drsw / dsx = (pw+1) * 1 / pooled_width * spatial_scale * src_w * exp(dsx) + 1 * 0.5 * spatial_scale * src_w * exp(dsx) = ( (pw+1)/pooled_width + 0.5 ) * spatial_scale * src_w * exp(dsx)
 
+    // dhs / dcy = dhs / dbh * dbh / dcy + dhs / drsh * drsh / dcy = ph * 0 + 1 * spatial_scale * src_h     = spatial_scale * src_w
+    // dhe / dcy = dhe / dbh * dbh / dcy + dhe / drsh * drsh / dcy = (ph+1) * 0 + 1 * spatial_scale * src_h = spatial_scale * src_h
+
+    // dhs / dsy = dhs / dbh * dbh / dsy + dhs / drsh * drsh / dsy = ph * 1 / pooled_height * spatial_scale * src_h * exp(dsy) + 1 * (-0.5) * spatial_scale * src_h * exp(dsy) = (ph / pooled_height - 0.5) * spatial_scale * src_h * exp(dsy) 
+    // dhe / dsy = dhe / dbh * dbh / dsy + dhe / drsh * drsh / dsy = (ph+1) * 1 / pooled_height * spatial_scale * src_h * exp(dsy) + 1 * 0.5 * spatial_scale * src_h * exp(dsy) = ((ph+1)/pooled_height + 0.5) * spatial_scale * src_h * exp(dsy)  
+
+    Dtype wctr = static_cast<Dtype>(wend-1+wstart) * 0.5;    // dwctr / dwe = 0.5; dwctr / dws = 0.5 
+    Dtype hctr = static_cast<Dtype>(hend-1+hstart) * 0.5;    // dhctr / dhe = 0.5; dhctr / dhs = 0.5 
+    Dtype wdiff = max(static_cast<Dtype>(wend-1-wstart), 1.);         // dwdiff / dwe = 1; dwdiff / dws = -1
+    Dtype hdiff = max(static_cast<Dtype>(hend-1-hstart), 1.);         // dhdiff / dhe = 1; dhdiff / dhs = -1
+    // dwctr / dcx = dwctr / dwe * dwe / dcx + dwctr / dws * dws / dcx = 0.5 * spatial_scale * src_w + 0.5 * spatial_scale * src_w = spatial_scale * src_w 
+    // dwdiff / dcx = dwdiff / dwe * dwe / dcx + dwdiff / dws * dws / dcx = 1 * spatial_scale * src_w -  1  * spatial_scale * src_w = 0 
+
+    // dhctr / dcy = spatial_scale * src_h
+    // dhdiff / dcy = 0
+  
+    // dwctr / dsx = dwctr / dwe * dwe / dsx + dwctr / dws * dws / dsx = 0.5 * ((pw+1)/pooled_width + 0.5) * spatial_scale * src_w * exp(dsx) + 0.5 * (pw/pooled_width - 0.5) * spatial_scale * src_w * exp(dsx)
+    //                                                                 = 0.5 * (2*pw+1)/pooled_width * spatial_scale * src_w * exp(dsx)
+    //                                                                 = (pw + 0.5) / pooled_width * spatial_scale * src_w * exp(dsx)
+    // dwdiff / dsx = dwdiff / dwe * dwe / dsx + dwdiff / dws * dws / dsx = 1 * ((pw+1)/pooled_width + 0.5) * spatial_scale * src_w * exp(dsx) + (-1) * (pw/pooled_width - 0.5) * spatial_scale * src_w * exp(dsx)
+    //                                                                    = (wend-wstart) >= 1 ? (1 / pooled_width + 1) * spatial_scale * src_w * exp(dsx) : 0
+    // dhctr / dsy  = (ph + 0.5) / pooled_height * spatial_scale * src_h * exp(dsy)
+    // dhdiff / dsy = (hend-hstart) >= 1 ? (1 / pooled_height + 1) * spatial_scale * src_h * exp(dsy) : 0
+    
     // Add roi offsets and clip to input boundaries
-    hstart = min(max(hstart + roi_start_h, 0), height);
-    hend = min(max(hend + roi_start_h, 0), height);
-    wstart = min(max(wstart + roi_start_w, 0), width);
-    wend = min(max(wend + roi_start_w, 0), width);
+    hstart = min(max(hstart, 0), height);         //  
+    hend = min(max(hend, 0), height);
+    wstart = min(max(wstart, 0), width);
+    wend = min(max(wend, 0), width);
     //bool is_empty = (hend <= hstart) || (wend <= wstart);
-
-    Dtype hdiff = static_cast<Dtype>(hend-1-hstart);  
-    Dtype wdiff = static_cast<Dtype>(wend-1-wstart);
 
     // Define an empty pooling region to be zero
     //Dtype maxval = is_empty ? 0 : -FLT_MAX;
@@ -97,22 +146,24 @@ __global__ void ROIWarpForward(const int nthreads, const Dtype* bottom_data,
     for (int h = hstart; h < hend; ++h) {
       for (int w = wstart; w < wend; ++w) {
         int bottom_index = h * width + w;
+        Dtype w_ = w, h_ = h;  
         //if (bottom_data[bottom_index] > maxval) {
         //  maxval = bottom_data[bottom_index];
         //  maxidx = bottom_index;
         //}
         //gain_x = max(0., 1 - abs( dst_ctr_x + static_cast<Dtype>(pw) / static_cast<Dtype>(pooled_width) * dst_scl_x - w ));
         //gain_y = max(0., 1 - abs( dst_ctr_y + static_cast<Dtype>(ph) / static_cast<Dtype>(pooled_height) * dst_scl_y - h));
-        gain_x = (wdiff - abs((static_cast<Dtype>(w) - wctr))) / static_cast<Dtype>(wdiff);
-        gain_y = (hdiff - abs((static_cast<Dtype>(h) - hctr))) / static_cast<Dtype>(hdiff); 
+        gain_x = (wdiff - abs((w_ - wctr))) / wdiff;
+        gain_y = (hdiff - abs((h_ - hctr))) / hdiff; 
         gain = gain_x * gain_y;
-        val = val + gain * bottom_data[bottom_index];
-        //val = val + gain;
+        //val = val + gain * bottom_data[bottom_index];
+        val = val + bottom_data[bottom_index];
       }
     }
     //top_data[index] = maxval;
     //argmax_data[index] = maxidx;
     top_data[index] = val;
+    //top_data[index] = static_cast<int>(floor(static_cast<Dtype>(ph) * bin_size_h)) + roi_start_h; 
   }
 }
 
@@ -155,46 +206,46 @@ void inn_ROIWarping_updateOutput(THCState *state,
   }
 }
 
-/*
-extern "C"
-void inn_ROIWarping_updateOutput(THCState *state,
-    THCudaTensor *output, THCudaTensor *indices,
-    THCudaTensor *data, THCudaTensor* rois, int W, int H, double spatial_scale)
-{
-  THAssert(THCudaTensor_nDimension(state, data) == 4);
-  THAssert(THCudaTensor_nDimension(state, rois) == 2 && rois->size[1] == 5);
-  THAssert(THCudaTensor_isContiguous(state, data));
-  THAssert(THCudaTensor_isContiguous(state, rois));
-  long num_rois = rois->size[0];
-  long nInputPlane = data->size[1];
-  THCudaTensor_resize4d(state, output, num_rois, nInputPlane, H, W);
-  THCudaTensor_resize4d(state, indices, num_rois, nInputPlane, H, W);
+//template <typename Dtype>
+//__global__ void ROIWarpBackwardAtomic(const int nthreads, const Dtype* top_diff,
+//    /*const int* argmax_data,*/ const int num_rois, const Dtype spatial_scale,
+//    const int channels, const int height, const int width,
+//    const int pooled_height, const int pooled_width, Dtype* bottom_diff,
+//    const Dtype* bottom_rois) {
+//  CUDA_KERNEL_LOOP(index, nthreads) {
+//    // (n, c, ph, pw) is an element in the pooled output
+//    int pw = index % pooled_width;
+//    int ph = (index / pooled_width) % pooled_height;
+//    int c = (index / pooled_width / pooled_height) % channels;
+//    int n = index / pooled_width / pooled_height / channels;
+//
+//    bottom_rois += n * 5;
+//    int roi_batch_ind = (bottom_rois[0] - 1);
+//    int bottom_offset = (roi_batch_ind * channels + c) * height * width;
+//    int top_offset    = (n * channels + c) * pooled_height * pooled_width;
+//    const Dtype* offset_top_diff = top_diff + top_offset;
+//    Dtype* offset_bottom_diff = bottom_diff + bottom_offset;
+//    //const int* offset_argmax_data = argmax_data + top_offset;
+//
+//    //int argmax = offset_argmax_data[ph*pooled_width + pw];
+//    //if(argmax != -1) {
+//    //  atomicAdd(offset_bottom_diff + argmax, offset_top_diff[ph * pooled_width + pw]);
+//    //}
+//  }
+//}
 
-  long count = THCudaTensor_nElement(state, output);
-
-  ROIWarpForward<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
-      count,
-      THCudaTensor_data(state, data),
-      spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
-      THCudaTensor_data(state, rois),
-      THCudaTensor_data(state, output),
-      (int*)THCudaTensor_data(state, indices)
-      );
-
-  // check for errors
-  cudaError_t err = cudaGetLastError();
-  if (err != cudaSuccess) {
-    printf("error in inn_ROIWarping_updateOutput: %s\n", cudaGetErrorString(err));
-    THError("aborting");
-  }
-}
-*/
-/*
 template <typename Dtype>
-__global__ void ROIWarpForwardV2(const int nthreads, const Dtype* bottom_data,
-    const Dtype spatial_scale, const int channels, const int height,
-    const int width, const int pooled_height, const int pooled_width,
-    const Dtype* bottom_rois, Dtype* top_data, int* argmax_data)  {
+__global__ void ROIWarpBackward(const int nthreads, const Dtype* bottom_data,
+    const Dtype spatial_scale, const int channels, const int height, const int width, 
+    const int pooled_height, const int pooled_width,
+    const Dtype* bottom_rois, const Dtype* bottom_delta_rois, 
+    const Dtype* top_diff,
+    Dtype* bottom_diff_data, 
+    Dtype* bottom_diff_delta_rois_buffer/*,
+    Dtype* bottom_diff_delta_rois_cx,
+    Dtype* bottom_diff_delta_rois_cy,
+    Dtype* bottom_diff_delta_rois_sx,
+    Dtype* bottom_diff_delta_rois_sy*/) {
   CUDA_KERNEL_LOOP(index, nthreads) {
     // (n, c, ph, pw) is an element in the pooled output
     int pw = index % pooled_width;
@@ -204,139 +255,234 @@ __global__ void ROIWarpForwardV2(const int nthreads, const Dtype* bottom_data,
 
     bottom_rois += n * 5;
     int roi_batch_ind = (bottom_rois[0] - 1);
-    int roi_start_w = round((bottom_rois[1] - 1) * spatial_scale);
-    int roi_start_h = round((bottom_rois[2] - 1)* spatial_scale);
-    int roi_end_w = round((bottom_rois[3] - 1) * spatial_scale) - 1;
-    int roi_end_h = round((bottom_rois[4] - 1) * spatial_scale) - 1;
 
+    Dtype src_w = bottom_rois[3] - bottom_rois[1] + 1; 
+    Dtype src_h = bottom_rois[4] - bottom_rois[2] + 1;
+    Dtype src_ctr_x = bottom_rois[1] + 0.5*(src_w-1.0); 
+    Dtype src_ctr_y = bottom_rois[2] + 0.5*(src_h-1.0); 
+
+    Dtype dst_ctr_x = bottom_delta_rois[1]; // dx (in fast-rcnn notation) = cx (in here)
+    Dtype dst_ctr_y = bottom_delta_rois[2]; // dy (in fast-rcnn notation) = cy (in here) 
+    Dtype dst_scl_x = bottom_delta_rois[3]; // dw (in fast-rcnn notation) = sx (in here)
+    Dtype dst_scl_y = bottom_delta_rois[4]; // dh (in fast-rcnn notation) = sy (in here) 
+
+    Dtype pred_ctr_x = dst_ctr_x * src_w + src_ctr_x; // dpcx / dcx = src_w
+    Dtype pred_ctr_y = dst_ctr_y * src_h + src_ctr_y; // dpcy / dcy = src_h
+    Dtype pred_w = exp(dst_scl_x) * src_w;            // dpw  / dsx = src_w * exp(dsx)  
+    Dtype pred_h = exp(dst_scl_y) * src_h;            // dph  / dsy = src_h * exp(dsy)  
+    
+    int roi_start_w = ( round(pred_ctr_x - 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drsw / dpcx = spatial_scale; drsw / dpw = -0.5 * spatial_scale
+    int roi_start_h = ( round(pred_ctr_y - 0.5*(pred_h-1)) - 1 ) * spatial_scale; // drsh / dpcy = spatial_scale; drsh / dph = -0.5 * spatial_scale
+    int roi_end_w =   ( round(pred_ctr_x + 0.5*(pred_w-1)) - 1 ) * spatial_scale; // drew / dpcx = spatial_scale; drew / dpw =  0.5 * spatial_scale
+    int roi_end_h =   ( round(pred_ctr_y + 0.5*(pred_h-1)) - 1 ) * spatial_scale; // dreh / dpcy = spatial_scale; dreh / dph =  0.5 * spatial_scale
+    assert(roi_end_w - roi_start_w >= 0); 
+    assert(roi_end_h - roi_start_h >= 0); 
+    
+    // drsw / dcx = drsw / dpcx * dpcx / dcx = spatial_scale * src_w
+    // drew / dcx = drew / dpcx * dpcx / dcx = spatial_scale * src_w
+
+    // drsh / dcy = drsh / dpcy * dpcy / dcy = spatial_scale * src_h
+    // dreh / dcy = dreh / dpcy * dpcy / dcy = spatial_scale * src_h
+
+    // drsw / dsx = drsw / dpw * dpw / dsx = -0.5 * spatial_scale * src_w * exp(dsx) 
+    // drew / dsx = drew / dpw * dpw / dsx =  0.5 * spatial_scale * src_w * exp(dsx)
+ 
+    // drsh / dsy = drsh / dph * dph / dsy = -0.5 * spatial_scale * src_h * exp(dsy)
+    // dreh / dsy = dreh / dph * dph / dsy =  0.5 * spatial_scale * src_h * exp(dsy) 
+ 
     // Force malformed ROIs to be 1x1
-    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
-    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
-    Dtype bin_size_h = static_cast<Dtype>(roi_height)
-                       / static_cast<Dtype>(pooled_height);
+    int roi_width  = roi_end_w - roi_start_w + 1;   // drw / drew = (rew - rsw) > 0 ?  1 : 0 
+                                                    // drw / drsw = (rew - rsw) > 0 ? -1 : 0
+    int roi_height = roi_end_h - roi_start_h + 1;   // drh / dreh = (reh - rsh) > 0 ?  1 : 0
+                                                    // drh / drsh = (reh - rsh) > 0 ? -1 : 0
+    // drw / dcx = drw / drew * drew / dcx + drw / drsw * drsw / dcx = drew / dcx - drsw / dcx = spatial_scale * src_w - spatial_scale * src_w = 0 
+    // drh / dcy = drh / dreh * dreh / dcy + drh / drsh * drsh / dcy = dreh / dcy - drsh / dcy = spatial_scale * src_h - spatial_scale * src_h = 0 
+    // drw / dsx = drw / drew * drew / dsx + drw / drsw * drsw / dsx = drew / dsx - drsw / dsx = 0.5 * spatial_scale * src_w * exp(dsx) - (-0.5 * spatial_scale * src_w * exp(dsx)) = spatial_scale * src_w * exp(dsx) 
+    // drh / dsy = drh / dreh * dreh / dsy + drh / drsh * drsh / dsy = dreh / dsy - drsh / dsy = 0.5 * spatial_scale * src_h * exp(dsy) - (-0.5 * spatial_scale * src_h * exp(dsy)) = spatial_scale * src_h * exp(dsy) 
+
     Dtype bin_size_w = static_cast<Dtype>(roi_width)
-                       / static_cast<Dtype>(pooled_width);
+                       / static_cast<Dtype>(pooled_width);  // dbw / drw  =  1 / pooled_width
+    Dtype bin_size_h = static_cast<Dtype>(roi_height)         
+                       / static_cast<Dtype>(pooled_height); // dbh / drh  =  1 / pooled_height
+    // dbw / dcx = dbw / drw * drw / dcx = 0 
+    // dbh / dcy = dbh / drh * drh / dcy = 0
+    // dbw / dsx = dbw / drw * drw / dsx = 1 / pooled_width * spatial_scale * src_w * exp(dsx) 
+    // dbh / dsy = dbh / drh * drh / dsy = 1 / pooled_height * spatial_scale * src_h * exp(dsy) 
 
-   int hstart = static_cast<int>(round(static_cast<Dtype>(ph)
-                                       * bin_size_h));
-   int wstart = static_cast<int>(round(static_cast<Dtype>(pw)
-                                       * bin_size_w));
-   int hend = static_cast<int>(round(static_cast<Dtype>(ph + 1)
-                                    * bin_size_h));
-   int wend = static_cast<int>(round(static_cast<Dtype>(pw + 1)
-                                    * bin_size_w));
+    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)        // dws / dbw = pw 
+                                        * bin_size_w)) + roi_start_w; // dws / drsw = 1
+    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)        // dhs / dbh = ph 
+                                        * bin_size_h)) + roi_start_h; // dhs / drsh = 1 
+    int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)       // dwe / dbw = (pw+1)
+                                     * bin_size_w)) + roi_start_w;    // dwe / drsw = 1 
+    int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)       // dhe / dbh = (ph+1)
+                                     * bin_size_h)) + roi_start_h;    // dhe / drsh = 1 
+    // dws / dcx = dws / dbw * dbw / dcx + dws / drsw * drsw / dcx = pw * 0 + 1 * spatial_scale * src_w     = spatial_scale * src_w
+    // dwe / dcx = dwe / dbw * dbw / dcx + dwe / drsw * drsw / dcx = (pw+1) * 0 + 1 * spatial_scale * src_w = spatial_scale * src_w
 
+    // dws / dsx = dws / dbw * dbw / dsx + dws / drsw * drsw / dsx = pw * 1 / pooled_width * spatial_scale * src_w * exp(dsx) + 1 * (-0.5) * spatial_scale * src_w * exp(dsx) = ( pw / pooled_width - 0.5 ) * spatial_scale * src_w * exp(dsx) 
+    // dwe / dsx = dwe / dbw * dbw / dsx + dwe / drsw * drsw / dsx = (pw+1) * 1 / pooled_width * spatial_scale * src_w * exp(dsx) + 1 * 0.5 * spatial_scale * src_w * exp(dsx) = ( (pw+1)/pooled_width + 0.5 ) * spatial_scale * src_w * exp(dsx)
+
+    // dhs / dcy = dhs / dbh * dbh / dcy + dhs / drsh * drsh / dcy = ph * 0 + 1 * spatial_scale * src_h     = spatial_scale * src_w
+    // dhe / dcy = dhe / dbh * dbh / dcy + dhe / drsh * drsh / dcy = (ph+1) * 0 + 1 * spatial_scale * src_h = spatial_scale * src_h
+
+    // dhs / dsy = dhs / dbh * dbh / dsy + dhs / drsh * drsh / dsy = ph * 1 / pooled_height * spatial_scale * src_h * exp(dsy) + 1 * (-0.5) * spatial_scale * src_h * exp(dsy) = (ph / pooled_height - 0.5) * spatial_scale * src_h * exp(dsy) 
+    // dhe / dsy = dhe / dbh * dbh / dsy + dhe / drsh * drsh / dsy = (ph+1) * 1 / pooled_height * spatial_scale * src_h * exp(dsy) + 1 * 0.5 * spatial_scale * src_h * exp(dsy) = ((ph+1)/pooled_height + 0.5) * spatial_scale * src_h * exp(dsy)  
+
+    Dtype wctr = static_cast<Dtype>(wend-1+wstart) * 0.5;      // dwctr / dwe = 0.5; dwctr / dws = 0.5 
+    Dtype hctr = static_cast<Dtype>(hend-1+hstart) * 0.5;      // dhctr / dhe = 0.5; dhctr / dhs = 0.5 
+    Dtype wdiff = max(static_cast<Dtype>(wend-1-wstart), 1.);  // dwdiff / dwe = (wend-wstart) >= 1 ? 1 : 0; dwdiff / dws = (wend-wstart) >= 1 ? -1 : 0; 
+    Dtype hdiff = max(static_cast<Dtype>(hend-1-hstart), 1.);  // dhdiff / dhe = (hend-hstart) >= 1 ? 1 : 0; dhdiff / dhs = (hend-hstart) >= 1 ? -1 : 0;
+    Dtype wdiff_mask = (wend-wstart) >= 1 ? 1 : 0;
+    Dtype hdiff_mask = (wend-wstart) >= 1 ? 1 : 0;
+    // dwctr / dcx = dwctr / dwe * dwe / dcx + dwctr / dws * dws / dcx = 0.5 * spatial_scale * src_w + 0.5 * spatial_scale * src_w = spatial_scale * src_w 
+    // dwdiff / dcx = dwdiff / dwe * dwe / dcx + dwdiff / dws * dws / dcx = 1 * spatial_scale * src_w -  1  * spatial_scale * src_w = 0 
+
+    // dhctr / dcy = spatial_scale * src_h
+    // dhdiff / dcy = 0
+  
+    // dwctr / dsx = dwctr / dwe * dwe / dsx + dwctr / dws * dws / dsx = 0.5 * ((pw+1)/pooled_width + 0.5) * spatial_scale * src_w * exp(dsx) + 0.5 * (pw/pooled_width - 0.5) * spatial_scale * src_w * exp(dsx) 
+    //                                                                 = 0.5 * (2*pw+1)/pooled_width * spatial_scale * src_w * exp(dsx)
+    //                                                                 = (pw + 0.5) / pooled_width * spatial_scale * src_w * exp(dsx) 
+    // dwdiff / dsx = dwdiff / dwe * dwe / dsx + dwdiff / dws * dws / dsx = 1 * ((pw+1)/pooled_width + 0.5) * spatial_scale * src_w * exp(dsx) + (-1) * (pw/pooled_width - 0.5) * spatial_scale * src_w * exp(dsx)
+    //                                                                    = (wend-wstart) >= 1 ? (1 / pooled_width + 1) * spatial_scale * src_w * exp(dsx) : 0 
+    // dhctr / dsy  = (ph + 0.5) / pooled_height * spatial_scale * src_h * exp(dsy)
+    // dhdiff / dsy = (hend-hstart) >= 1 ? (1 / pooled_height + 1) * spatial_scale * src_h * exp(dsy) : 0
+  
+    // if w >= wctr  
+    // dgx / dcx = dgx / dwctr * dwctr / dcx + dgx / dwdiff * dwdiff / dcx = 1 / wdiff * spatial_scale * src_w + (( w - wctr ) / (wdiff)^2 ) * 0
+    //                                                                     = 1 / wdiff * spatial_scale * src_w  
+    // dgx / dsx = dgx / dwctr * dwctr / dsx + dgx / dwdiff * dwdiff / dsx = 1 / wdiff * (pw + 0.5) / pooled_width * spatial_scale * src_w * exp(dsx) + ((wend-wstart) >= 1 ? 1 : 0) * (( w - wctr ) / (wdiff)^2 ) * (1 / pooled_width + 1) * spatial_scale * src_w * exp(dsx)
+    //                                                                     = ((pw * 0.5) / (pooled_width * wdiff) + ((wend-wstart) >= 1 ? 1 : 0) * (( w - wctr ) / (wdiff)^2 ) * (1 + pooled_width) / pooled_width ) * spatial_scale * src_w * exp(dsx) 
+    // dgy / dcy = dgy / dhctr * dhctr / dcy + dgy / dhdiff * dhdiff / dcy = 1 / hdiff * spatial_scale * src_h
+    // dgy / dsy = dgy / dhctr * dhctr / dsy + dgy / dhdiff * dhdiff / dsy = ((ph * 0.5) / (pooled_height * hdiff) + ((hend-hstart) >= 1 ? 1 : 0) * (( h - hctr ) / (hdiff)^2 ) * (1 + pooled_height) / pooled_height ) * spatial_scale * src_h * exp(dsy) 
+  
+  
     // Add roi offsets and clip to input boundaries
-    hstart = min(max(hstart + roi_start_h, 0), height);
-    hend = min(max(hend + roi_start_h, 0), height);
-    wstart = min(max(wstart + roi_start_w, 0), width);
-    wend = min(max(wend + roi_start_w, 0), width);
-    bool is_empty = (hend <= hstart) || (wend <= wstart);
+    hstart = min(max(hstart, 0), height);         //  
+    hend = min(max(hend, 0), height);
+    wstart = min(max(wstart, 0), width);
+    wend = min(max(wend, 0), width);
+    //bool is_empty = (hend <= hstart) || (wend <= wstart);
 
     // Define an empty pooling region to be zero
-    Dtype maxval = is_empty ? 0 : -FLT_MAX;
-    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
-    int maxidx = -1;
-    bottom_data += (roi_batch_ind * channels + c) * height * width;
+    Dtype val_cx = 0, val_cy = 0, val_sx = 0, val_sy = 0; 
+    Dtype gain = 0, gain_x = 0, gain_y = 0;  
+    Dtype pw_ = static_cast<Dtype>(pw); 
+    Dtype ph_ = static_cast<Dtype>(ph);
+    Dtype pooled_width_  = static_cast<Dtype>(pooled_width); 
+    Dtype pooled_height_ = static_cast<Dtype>(pooled_height);
+    Dtype src_w_ = static_cast<Dtype>(src_w); 
+    Dtype src_h_ = static_cast<Dtype>(src_h);  
+    Dtype buffer_sx = 0, buffer_sy = 0;  
+    //bottom_data += (roi_batch_ind * channels + c) * height * width;
+    bottom_diff_data += (roi_batch_ind * channels + c) * height * width;
     for (int h = hstart; h < hend; ++h) {
       for (int w = wstart; w < wend; ++w) {
         int bottom_index = h * width + w;
-        if (bottom_data[bottom_index] > maxval) {
-          maxval = bottom_data[bottom_index];
-          maxidx = bottom_index;
-        }
+        Dtype w_ = w, h_ = h;  
+        gain_x = (wdiff - abs((w_ - wctr))) / wdiff;   // dgx / dwdiff =   (w-wctr) / (wdiff)^2 ( if w >= wctr ) 
+                                                       // dgx / dwdiff = - (w-wctr) / (wdiff)^2 ( else )
+                                                       // dgx / dwctr  =   1 / wdiff ( if w >= wctr )  
+                                                       // dgx / dwctr  = - 1 / wdiff ( else )  
+        gain_y = (hdiff - abs((h_ - hctr))) / hdiff;   // dgy / dhdiff =   (h-hctr) / (hdiff)^2 ( if h >= hctr ) 
+                                                                                              // dgy / dhdiff = - (h-hctr) / (hdiff)^2 ( else )
+                                                                                              // dgy / dhctr  =   1 / hdiff ( if h >= hctr )
+                                                                                              // dgy / dhdiff = - 1 / hdiff ( else )
+        gain = gain_x * gain_y;
+        //val = val + gain * bottom_data[bottom_index];
+        //bottom_diff_data[bottom_index] = bottom_diff_data[bottom_index] + gain * top_diff[index];
+        bottom_diff_data[bottom_index] = bottom_diff_data[bottom_index] + top_diff[index];
+
+        // buffer 
+        Dtype coeff_x = w >= wctr ? 1 : -1; coeff_x = coeff_x * gain_y * spatial_scale * src_w_ * top_diff[index]; 
+        Dtype coeff_y = h >= hctr ? 1 : -1; coeff_y = coeff_y * gain_x * spatial_scale * src_h_ * top_diff[index]; 
+        val_cx = val_cx + coeff_x / wdiff;  
+        val_cy = val_cy + coeff_y / hdiff;
+        //val_sx = val_sx + coeff_x * (pw_ * 0.5 * wdiff + (w_ - wctr) * (1 + pooled_width_ )) / (wdiff*wdiff) / pooled_width_  * exp(dst_scl_x);
+        //val_sy = val_sy + coeff_y * (ph_ * 0.5 * hdiff + (h_ - hctr) * (1 + pooled_height_)) / (hdiff*hdiff) / pooled_height_ * exp(dst_scl_y);
+        buffer_sx = 0; buffer_sx = coeff_x * (pw_ * 0.5 * wdiff + wdiff_mask * (w_ - wctr) * (1 + pooled_width_ )); buffer_sx = buffer_sx / (wdiff*wdiff); buffer_sx = buffer_sx / pooled_width_  * exp(dst_scl_x);  
+        val_sx = val_sx + buffer_sx; 
+        buffer_sy = 0; buffer_sy = coeff_y * (ph_ * 0.5 * hdiff + hdiff_mask * (h_ - hctr) * (1 + pooled_height_)); buffer_sy = buffer_sy / (hdiff*hdiff); buffer_sy = buffer_sy / pooled_height_ * exp(dst_scl_y);
+        val_sy = val_sy + buffer_sy; 
+        //(dgain/ddelta_rois) * top_diff[index]; // dgain/ddeleta_rois = dgain/dgain_x * dgain_x/ddelta_rois + dgain/dgain_y * dgain_y/ddelta_rois
+                                                 //                    =        gain_y * dgain_x/ddelta_rois +        gain_x * dgain_y/ddelta_rois
       }
     }
-    top_data[index] = maxval;
-    argmax_data[index] = maxidx;
+    int buffer_index = n * (channels * pooled_height * pooled_width * 4) + c * (pooled_height * pooled_width * 4) + ph * (pooled_width * 4) + pw * 4; 
+    bottom_diff_delta_rois_buffer[buffer_index+0] = val_cx; 
+    bottom_diff_delta_rois_buffer[buffer_index+1] = val_cy; 
+    bottom_diff_delta_rois_buffer[buffer_index+2] = val_sx;
+    bottom_diff_delta_rois_buffer[buffer_index+3] = val_sy;
+    //bottom_diff_delta_rois_cx[index] = val_cx;
+    //bottom_diff_delta_rois_cy[index] = val_cy;
+    //bottom_diff_delta_rois_sx[index] = val_sx;
+    //bottom_diff_delta_rois_sy[index] = val_sy;
   }
 }
 
-extern "C"
-void inn_ROIWarping_updateOutputV2(THCState *state,
-    THCudaTensor *output, THCudaTensor *indices,
-    THCudaTensor *data, THCudaTensor* rois, int W, int H, double spatial_scale)
-{
-  THAssert(THCudaTensor_nDimension(state, data) == 4);
-  THAssert(THCudaTensor_nDimension(state, rois) == 2 && rois->size[1] == 5);
-  THAssert(THCudaTensor_isContiguous(state, data));
-  THAssert(THCudaTensor_isContiguous(state, rois));
-  long num_rois = rois->size[0];
-  long nInputPlane = data->size[1];
-  THCudaTensor_resize4d(state, output, num_rois, nInputPlane, H, W);
-  THCudaTensor_resize4d(state, indices, num_rois, nInputPlane, H, W);
-
-  long count = THCudaTensor_nElement(state, output);
-
-  ROIWarpForwardV2<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
-      count,
-      THCudaTensor_data(state, data),
-      spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
-      THCudaTensor_data(state, rois),
-      THCudaTensor_data(state, output),
-      (int*)THCudaTensor_data(state, indices)
-      );
-
-  // check for errors
-  cudaError_t err = cudaGetLastError();
-  if (err != cudaSuccess) {
-    printf("error in inn_ROIWarping_updateOutput: %s\n", cudaGetErrorString(err));
-    THError("aborting");
-  }
-}
-*/
-
-template <typename Dtype>
-__global__ void ROIWarpBackwardAtomic(const int nthreads, const Dtype* top_diff,
-    const int* argmax_data, const int num_rois, const Dtype spatial_scale,
-    const int channels, const int height, const int width,
-    const int pooled_height, const int pooled_width, Dtype* bottom_diff,
-    const Dtype* bottom_rois) {
-  CUDA_KERNEL_LOOP(index, nthreads) {
-    // (n, c, ph, pw) is an element in the pooled output
-    int pw = index % pooled_width;
-    int ph = (index / pooled_width) % pooled_height;
-    int c = (index / pooled_width / pooled_height) % channels;
-    int n = index / pooled_width / pooled_height / channels;
-
-    bottom_rois += n * 5;
-    int roi_batch_ind = (bottom_rois[0] - 1);
-    int bottom_offset = (roi_batch_ind * channels + c) * height * width;
-    int top_offset    = (n * channels + c) * pooled_height * pooled_width;
-    const Dtype* offset_top_diff = top_diff + top_offset;
-    Dtype* offset_bottom_diff = bottom_diff + bottom_offset;
-    const int* offset_argmax_data = argmax_data + top_offset;
-
-    int argmax = offset_argmax_data[ph*pooled_width + pw];
-    if(argmax != -1) {
-      atomicAdd(offset_bottom_diff + argmax, offset_top_diff[ph * pooled_width + pw]);
-    }
-  }
-}
 
 extern "C"
 void inn_ROIWarping_updateGradInputAtomic(THCState *state,
-    THCudaTensor *gradInput, THCudaTensor *indices, THCudaTensor *data,
+    THCudaTensor *gradInput_data, THCudaTensor *data,
+    THCudaTensor *gradInput_delta_rois, THCudaTensor *delta_rois,
+    //THCudaTensor *gradInput_delta_rois_dx,
+    //THCudaTensor *gradInput_delta_rois_dy,
+    //THCudaTensor *gradInput_delta_rois_dw,
+    //THCudaTensor *gradInput_delta_rois_dh,
+    THCudaTensor *gradInput_delta_rois_buffer,
     THCudaTensor *gradOutput, THCudaTensor* rois, int W, int H, double spatial_scale)
 {
   THAssert(THCudaTensor_nDimension(state, data) == 4);
   THAssert(THCudaTensor_nDimension(state, rois) == 2 && rois->size[1] == 5);
+  THAssert(THCudaTensor_nDimension(state, delta_rois) == 2 && delta_rois->size[1] == 5);
+  THAssert(THCudaTensor_nDimension(state, rois) == THCudaTensor_nDimension(state, delta_rois) &&
+           rois->size[0] == delta_rois->size[0] &&
+           rois->size[1] == delta_rois->size[1]);
   THAssert(THCudaTensor_isContiguous(state, data));
   THAssert(THCudaTensor_isContiguous(state, rois));
+  THAssert(THCudaTensor_isContiguous(state, delta_rois));
   long num_rois = rois->size[0];
   long nInputPlane = data->size[1];
-  THCudaTensor_resizeAs(state, gradInput, data);
-  THCudaTensor_zero(state, gradInput);
+  THCudaTensor_resizeAs(state, gradInput_data, data);
+  THCudaTensor_zero(state, gradInput_data);
+  THCudaTensor_resizeAs(state, gradInput_delta_rois, delta_rois);
+  THCudaTensor_zero(state, gradInput_delta_rois);
+
+  THCudaTensor_resize5d(state, gradInput_delta_rois_buffer, num_rois, nInputPlane, H, W, 4);
+  THCudaTensor_zero(state, gradInput_delta_rois_buffer);
+  //THCudaTensor_resizeAs(state, gradInput_delta_rois_dx, gradOutput);
+  //THCudaTensor_zero(state, gradInput_delta_rois_dx);
+  //THCudaTensor_resizeAs(state, gradInput_delta_rois_dy, gradOutput);
+  //THCudaTensor_zero(state, gradInput_delta_rois_dy);
+  //THCudaTensor_resizeAs(state, gradInput_delta_rois_dw, gradOutput);
+  //THCudaTensor_zero(state, gradInput_delta_rois_dw);
+  //THCudaTensor_resizeAs(state, gradInput_delta_rois_dh, gradOutput);
+  //THCudaTensor_zero(state, gradInput_delta_rois_dh);
 
   long count = THCudaTensor_nElement(state, gradOutput);
 
-  ROIWarpBackwardAtomic<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+  //ROIWarpBackwardAtomic<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+  //    count,
+  //    THCudaTensor_data(state, gradOutput),
+  //    //(int*)THCudaTensor_data(state, indices),
+  //    num_rois, spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
+  //    THCudaTensor_data(state, gradInput_data),
+  //    THCudaTensor_data(state, rois)
+  //    );
+  ROIWarpBackward<float><<<GET_BLOCKS(count), CUDA_NUM_THREADS / 2, 0, THCState_getCurrentStream(state)>>>(
       count,
-      THCudaTensor_data(state, gradOutput),
-      (int*)THCudaTensor_data(state, indices),
-      num_rois, spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
-      THCudaTensor_data(state, gradInput),
-      THCudaTensor_data(state, rois)
+      THCudaTensor_data(state, data),
+      spatial_scale, nInputPlane, data->size[2], data->size[3], H, W,
+      THCudaTensor_data(state, rois),
+      THCudaTensor_data(state, delta_rois),
+      THCudaTensor_data(state, gradOutput), 
+      THCudaTensor_data(state, gradInput_data),
+      THCudaTensor_data(state, gradInput_delta_rois_buffer)/*,
+      THCudaTensor_data(state, gradInput_delta_rois_dx),
+      THCudaTensor_data(state, gradInput_delta_rois_dy),
+      THCudaTensor_data(state, gradInput_delta_rois_dw),
+      THCudaTensor_data(state, gradInput_delta_rois_dh)*/
       );
 
   // check for errors

--- a/ROIWarping.lua
+++ b/ROIWarping.lua
@@ -76,7 +76,7 @@ function ROIWarping:updateGradInput(input,gradOutput)
     gradOutput:cdata(), self.output_buffer:cdata(), 
     rois:cdata(), self.W, self.H, self.spatial_scale)
 
-  --print(self.gradInput_delta_rois_buffer[{1, 1, 1, 1, {}}])
+ --print(self.gradInput_delta_rois_buffer)
 
   self.gradInput_rois:resizeAs(rois):zero()
 

--- a/ROIWarping.lua
+++ b/ROIWarping.lua
@@ -27,16 +27,11 @@ function ROIWarping:updateOutput(input)
     self.delta_rois = self.delta_rois or rois.new()
     self.delta_rois:resizeAs(rois):zero()
     self.delta_rois[{{}, 1}] = rois[{{}, 1}] 
-    --delta_rois = rois:clone()
-    --delta_rois[{{},{2,5}}] = 0
     delta_rois = self.delta_rois
   end
  
   self.output_buffer = self.output_buffer or data.new()
  
-  --C.inn_ROIWarping_updateOutput(cutorch.getState(),
-  --  self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(), delta_rois:cdata(), 
-  --  self.W, self.H, self.spatial_scale)
   C.inn_ROIWarping_updateOutput(cutorch.getState(),
     self.output:cdata(), self.output_buffer:cdata(),
     data:cdata(), rois:cdata(), delta_rois:cdata(),

--- a/ROIWarping.lua
+++ b/ROIWarping.lua
@@ -23,16 +23,14 @@ function ROIWarping:updateOutput(input)
   local delta_rois 
   if #input == 3 then
     delta_rois = input[3]
-  else -- #input == 2  
-    delta_rois = rois:clone()
-    --delta_rois[{{}, 2}] = rois[{{},2}] + (rois[{{}, 4}] - rois[{{},2}]) / 2
-    --delta_rois[{{}, 3}] = rois[{{},3}] + (rois[{{}, 5}] - rois[{{},3}]) / 2
-    delta_rois[{{},{2,3}}] = 0 
-    delta_rois[{{},{4,5}}] = 1
+  else -- #input == 2 
+    self.delta_rois = self.delta_rois or rois.new()
+    self.delta_rois:resizeAs(rois):zero()
+    self.delta_rois[{{}, 1}] = rois[{{}, 1}] 
+    --delta_rois = rois:clone()
+    --delta_rois[{{},{2,5}}] = 0
+    delta_rois = self.delta_rois
   end
-  --print('hi')
-  --print(rois)
-  --print(delta_rois)
   
   --C.inn_ROIWarping_updateOutput(cutorch.getState(),
   --  self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(), delta_rois:cdata(), 
@@ -51,22 +49,41 @@ function ROIWarping:updateGradInput(input,gradOutput)
   if #input == 3 then
     delta_rois = input[3]
   else -- #input == 2
-    delta_rois = rois:clone()
-    delta_rois[{{},{2,3}}] = 0
-    delta_rois[{{},{4,5}}] = 1
+    self.delta_rois = self.delta_rois or data.new()
+    self.delta_rois:resizeAs(rois):zero()
+    self.delta_rois[{{}, 1}] = rois[{{}, 1}]
+    delta_rois = self.delta_rois
   end
 
   self.gradInput_boxes = self.gradInput_boxes or data.new()
-  self.gradInput_rois = self.gradInput_rois or data.new()
-  if #input == 3 then 
-    self.gradInput_delta_rois = self.gradInput_delta_rois or data.new()
-  end 
+  self.gradInput_rois = self.gradInput_rois or rois.new()
+  self.gradInput_delta_rois = self.gradInput_delta_rois or delta_rois.new()
+  --if #input == 3 then 
+    --self.gradInput_delta_rois_dx = self.gradInput_delta_rois_dx or self.output.new()
+    --self.gradInput_delta_rois_dy = self.gradInput_delta_rois_dy or self.output.new()
+    --self.gradInput_delta_rois_dw = self.gradInput_delta_rois_dw or self.output.new()
+    --self.gradInput_delta_rois_dh = self.gradInput_delta_rois_dh or self.output.new()
+    self.gradInput_delta_rois_buffer = self.gradInput_delta_rois_buffer or self.output.new()
+  --end 
 
   --C.inn_ROIWarping_updateGradInputAtomic(cutorch.getState(),
   --  self.gradInput_boxes:cdata(), self.indices:cdata(), data:cdata(),
   --  gradOutput:cdata(), rois:cdata(), self.W, self.H, self.spatial_scale)
+  C.inn_ROIWarping_updateGradInputAtomic(cutorch.getState(),
+    self.gradInput_boxes:cdata(), data:cdata(),
+    self.gradInput_delta_rois:cdata(), delta_rois:cdata(),
+    --self.gradInput_delta_rois_dx:cdata(),  
+    --self.gradInput_delta_rois_dy:cdata(),  
+    --self.gradInput_delta_rois_dw:cdata(),  
+    --self.gradInput_delta_rois_dh:cdata(),  
+    self.gradInput_delta_rois_buffer:cdata(),  
+    gradOutput:cdata(), rois:cdata(), self.W, self.H, self.spatial_scale)
+
+  --print(self.gradInput_delta_rois_buffer[{1, 1, 1, 1, {}}])
 
   self.gradInput_rois:resizeAs(rois):zero()
+
+  self.gradInput_delta_rois[{{}, {2, 5}}] = self.gradInput_delta_rois_buffer:sum(2):sum(3):sum(4):view(rois:size()[1], 4)
 
   self.gradInput = {self.gradInput_boxes, self.gradInput_rois, self.gradInput_delta_rois}
 
@@ -74,6 +91,6 @@ function ROIWarping:updateGradInput(input,gradOutput)
 end
 
 function ROIWarping:clearState()
-   nn.utils.clear(self, 'gradInput_rois', 'gradInput_boxes', 'indices')
+   nn.utils.clear(self, 'gradInput_rois', 'gradInput_boxes', 'gradInput_delta_rois', 'gradInput_delta_rois_dx', 'gradInput_delta_rois_dy', 'gradInput_delta_rois_sx', 'gradInput_delta_rois_sy')
    return parent.clearState(self)
 end

--- a/ROIWarping.lua
+++ b/ROIWarping.lua
@@ -1,0 +1,88 @@
+local ROIWarping,parent = torch.class('inn.ROIWarping', 'nn.Module')
+local C = inn.C
+
+function ROIWarping:__init(W,H,spatial_scale)
+  parent.__init(self)
+  assert(W and H, 'W and H have to be provided')
+  self.W = W
+  self.H = H
+  self.spatial_scale = spatial_scale or 1
+  self.gradInput = {}
+  self.indices = torch.Tensor()
+  print('hi11111111') 
+end
+
+function ROIWarping:setSpatialScale(scale)
+  self.spatial_scale = scale
+  return self
+end
+
+function ROIWarping:updateOutput(input)
+  assert(#input == 2 or #input == 3)
+  local data = input[1]
+  local rois = input[2]
+  local delta_rois 
+  if #input == 3 then
+    delta_rois = input[3]
+  else -- #input == 2  
+    delta_rois = rois:clone()
+    --delta_rois[{{}, 2}] = rois[{{},2}] + (rois[{{}, 4}] - rois[{{},2}]) / 2
+    --delta_rois[{{}, 3}] = rois[{{},3}] + (rois[{{}, 5}] - rois[{{},3}]) / 2
+    delta_rois[{{},{2,3}}] = 0 
+    delta_rois[{{},{4,5}}] = 1
+  end
+  --print('hi')
+  --print(rois)
+  --print(delta_rois)
+  
+  --if self.v2 then
+  --  C.inn_ROIWarping_updateOutputV2(cutorch.getState(),
+  --    self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(),
+  --    self.W, self.H, self.spatial_scale)
+  --else
+  --if #input == 3 then 
+    C.inn_ROIWarping_updateOutput(cutorch.getState(),
+      self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(), delta_rois:cdata(), 
+      self.W, self.H, self.spatial_scale)
+  --elseif #input == 2 then 
+  --  C.inn_ROIWarping_updateOutput(cutorch.getState(),
+  --    self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(),
+  --    self.W, self.H, self.spatial_scale)    
+  --end
+  --end
+  return self.output
+end
+
+function ROIWarping:updateGradInput(input,gradOutput)
+  local data = input[1]
+  local rois = input[2]
+  local delta_rois
+  if #input == 3 then
+    delta_rois = input[3]
+  else -- #input == 2
+    delta_rois = rois:clone()
+    delta_rois[{{},{2,3}}] = 0
+    delta_rois[{{},{4,5}}] = 1
+  end
+
+  self.gradInput_boxes = self.gradInput_boxes or data.new()
+  self.gradInput_rois = self.gradInput_rois or data.new()
+  if #input == 3 then 
+    self.gradInput_delta_rois = self.gradInput_delta_rois or data.new()
+  end 
+
+  C.inn_ROIWarping_updateGradInputAtomic(cutorch.getState(),
+    self.gradInput_boxes:cdata(), self.indices:cdata(), data:cdata(),
+    gradOutput:cdata(), rois:cdata(), self.W, self.H, self.spatial_scale)
+
+  self.gradInput_rois:resizeAs(rois):zero()
+
+  self.gradInput = {self.gradInput_boxes, self.gradInput_rois, self.gradInput_delta_rois}
+
+  return self.gradInput
+end
+
+function ROIWarping:clearState()
+   nn.utils.clear(self, 'gradInput_rois', 'gradInput_boxes', 'indices')
+   return parent.clearState(self)
+end

--- a/ROIWarping.lua
+++ b/ROIWarping.lua
@@ -31,12 +31,15 @@ function ROIWarping:updateOutput(input)
     --delta_rois[{{},{2,5}}] = 0
     delta_rois = self.delta_rois
   end
-  
+ 
+  self.output_buffer = self.output_buffer or data.new()
+ 
   --C.inn_ROIWarping_updateOutput(cutorch.getState(),
   --  self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(), delta_rois:cdata(), 
   --  self.W, self.H, self.spatial_scale)
   C.inn_ROIWarping_updateOutput(cutorch.getState(),
-    self.output:cdata(), data:cdata(), rois:cdata(), delta_rois:cdata(), 
+    self.output:cdata(), self.output_buffer:cdata(),
+    data:cdata(), rois:cdata(), delta_rois:cdata(),
     self.W, self.H, self.spatial_scale)
 
   return self.output
@@ -66,14 +69,12 @@ function ROIWarping:updateGradInput(input,gradOutput)
     self.gradInput_delta_rois_buffer = self.gradInput_delta_rois_buffer or self.output.new()
   --end 
 
-  --C.inn_ROIWarping_updateGradInputAtomic(cutorch.getState(),
-  --  self.gradInput_boxes:cdata(), self.indices:cdata(), data:cdata(),
-  --  gradOutput:cdata(), rois:cdata(), self.W, self.H, self.spatial_scale)
   C.inn_ROIWarping_updateGradInputAtomic(cutorch.getState(),
-    self.gradInput_boxes:cdata(), data:cdata(),
+    self.gradInput_boxes:cdata(), data:cdata(), 
     self.gradInput_delta_rois:cdata(), delta_rois:cdata(),
     self.gradInput_delta_rois_buffer:cdata(),  
-    gradOutput:cdata(), rois:cdata(), self.W, self.H, self.spatial_scale)
+    gradOutput:cdata(), self.output_buffer:cdata(), 
+    rois:cdata(), self.W, self.H, self.spatial_scale)
 
   --print(self.gradInput_delta_rois_buffer[{1, 1, 1, 1, {}}])
 

--- a/ROIWarping.lua
+++ b/ROIWarping.lua
@@ -72,10 +72,6 @@ function ROIWarping:updateGradInput(input,gradOutput)
   C.inn_ROIWarping_updateGradInputAtomic(cutorch.getState(),
     self.gradInput_boxes:cdata(), data:cdata(),
     self.gradInput_delta_rois:cdata(), delta_rois:cdata(),
-    --self.gradInput_delta_rois_dx:cdata(),  
-    --self.gradInput_delta_rois_dy:cdata(),  
-    --self.gradInput_delta_rois_dw:cdata(),  
-    --self.gradInput_delta_rois_dh:cdata(),  
     self.gradInput_delta_rois_buffer:cdata(),  
     gradOutput:cdata(), rois:cdata(), self.W, self.H, self.spatial_scale)
 

--- a/ROIWarping.lua
+++ b/ROIWarping.lua
@@ -8,8 +8,7 @@ function ROIWarping:__init(W,H,spatial_scale)
   self.H = H
   self.spatial_scale = spatial_scale or 1
   self.gradInput = {}
-  self.indices = torch.Tensor()
-  print('hi11111111') 
+  --self.indices = torch.Tensor()
 end
 
 function ROIWarping:setSpatialScale(scale)
@@ -35,21 +34,13 @@ function ROIWarping:updateOutput(input)
   --print(rois)
   --print(delta_rois)
   
-  --if self.v2 then
-  --  C.inn_ROIWarping_updateOutputV2(cutorch.getState(),
-  --    self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(),
-  --    self.W, self.H, self.spatial_scale)
-  --else
-  --if #input == 3 then 
-    C.inn_ROIWarping_updateOutput(cutorch.getState(),
-      self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(), delta_rois:cdata(), 
-      self.W, self.H, self.spatial_scale)
-  --elseif #input == 2 then 
-  --  C.inn_ROIWarping_updateOutput(cutorch.getState(),
-  --    self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(),
-  --    self.W, self.H, self.spatial_scale)    
-  --end
-  --end
+  --C.inn_ROIWarping_updateOutput(cutorch.getState(),
+  --  self.output:cdata(), self.indices:cdata(), data:cdata(), rois:cdata(), delta_rois:cdata(), 
+  --  self.W, self.H, self.spatial_scale)
+  C.inn_ROIWarping_updateOutput(cutorch.getState(),
+    self.output:cdata(), data:cdata(), rois:cdata(), delta_rois:cdata(), 
+    self.W, self.H, self.spatial_scale)
+
   return self.output
 end
 
@@ -71,9 +62,9 @@ function ROIWarping:updateGradInput(input,gradOutput)
     self.gradInput_delta_rois = self.gradInput_delta_rois or data.new()
   end 
 
-  C.inn_ROIWarping_updateGradInputAtomic(cutorch.getState(),
-    self.gradInput_boxes:cdata(), self.indices:cdata(), data:cdata(),
-    gradOutput:cdata(), rois:cdata(), self.W, self.H, self.spatial_scale)
+  --C.inn_ROIWarping_updateGradInputAtomic(cutorch.getState(),
+  --  self.gradInput_boxes:cdata(), self.indices:cdata(), data:cdata(),
+  --  gradOutput:cdata(), rois:cdata(), self.W, self.H, self.spatial_scale)
 
   self.gradInput_rois:resizeAs(rois):zero()
 

--- a/ffi.lua
+++ b/ffi.lua
@@ -22,13 +22,14 @@ void inn_ROIPooling_updateGradInputAtomic(THCState *state,
     THCudaTensor *gradOutput, THCudaTensor* rois, int W, int H, double spatial_scale);
 
 void inn_ROIWarping_updateOutput(THCState *state,
-    THCudaTensor *output, 
+    THCudaTensor *output, THCudaTensor *output_buffer, 
     THCudaTensor *data, THCudaTensor* rois, THCudaTensor* delta_rois, int W, int H, double spatial_scale);
 void inn_ROIWarping_updateGradInputAtomic(THCState *state,
-    THCudaTensor *gradInput_data, THCudaTensor *data,
+    THCudaTensor *gradInput_data, THCudaTensor *data, 
     THCudaTensor *gradInput_delta_rois, THCudaTensor *delta_rois,
     THCudaTensor *gradInput_delta_rois_buffer,
-    THCudaTensor *gradOutput, THCudaTensor* rois, int W, int H, double spatial_scale);
+    THCudaTensor *gradOutput, THCudaTensor *top_data_buffer,
+    THCudaTensor* rois, int W, int H, double spatial_scale);
 ]]
 
 return ffi.load(libpath)

--- a/ffi.lua
+++ b/ffi.lua
@@ -20,6 +20,10 @@ void inn_ROIPooling_updateOutputV2(THCState *state,
 void inn_ROIPooling_updateGradInputAtomic(THCState *state,
     THCudaTensor *gradInput, THCudaTensor *indices, THCudaTensor *data,
     THCudaTensor *gradOutput, THCudaTensor* rois, int W, int H, double spatial_scale);
+
+void inn_ROIWarping_updateOutput(THCState *state,
+    THCudaTensor *output, THCudaTensor *indices,
+    THCudaTensor *data, THCudaTensor* rois, THCudaTensor* delta_rois, int W, int H, double spatial_scale);
 ]]
 
 return ffi.load(libpath)

--- a/ffi.lua
+++ b/ffi.lua
@@ -24,6 +24,11 @@ void inn_ROIPooling_updateGradInputAtomic(THCState *state,
 void inn_ROIWarping_updateOutput(THCState *state,
     THCudaTensor *output, 
     THCudaTensor *data, THCudaTensor* rois, THCudaTensor* delta_rois, int W, int H, double spatial_scale);
+void inn_ROIWarping_updateGradInputAtomic(THCState *state,
+    THCudaTensor *gradInput_data, THCudaTensor *data,
+    THCudaTensor *gradInput_delta_rois, THCudaTensor *delta_rois,
+    THCudaTensor *gradInput_delta_rois_buffer,
+    THCudaTensor *gradOutput, THCudaTensor* rois, int W, int H, double spatial_scale);
 ]]
 
 return ffi.load(libpath)

--- a/ffi.lua
+++ b/ffi.lua
@@ -22,7 +22,7 @@ void inn_ROIPooling_updateGradInputAtomic(THCState *state,
     THCudaTensor *gradOutput, THCudaTensor* rois, int W, int H, double spatial_scale);
 
 void inn_ROIWarping_updateOutput(THCState *state,
-    THCudaTensor *output, THCudaTensor *indices,
+    THCudaTensor *output, 
     THCudaTensor *data, THCudaTensor* rois, THCudaTensor* delta_rois, int W, int H, double spatial_scale);
 ]]
 

--- a/init.lua
+++ b/init.lua
@@ -9,4 +9,5 @@ require 'inn.MeanSubtraction'
 require 'inn.SpatialPyramidPooling'
 require 'inn.SpatialSameResponseNormalization'
 require 'inn.ROIPooling'
+require 'inn.ROIWarping'
 return inn

--- a/test/test_jacobian.lua
+++ b/test/test_jacobian.lua
@@ -222,11 +222,11 @@ function testJacobianWithRandomROIForROIWarping2(cls)
   end
 
   --pooling grid size
-  local w=3; --w=4;
-  local h=2; --h=4;
+  local w=4;
+  local h=4;
   --img size
-  local W=4; --local W=w*2;
-  local H=4; --local H=h*2;
+  local W=w*2;
+  local H=h*2;
   
 
   local batchSize = 3

--- a/test/test_roiwarping.lua
+++ b/test/test_roiwarping.lua
@@ -37,19 +37,21 @@ local input_image = torch.Tensor(n_images, sz[1], sz[2], sz[3]):copy(torch.linsp
 
 print(input_image)
 
-local n_rois = 2
+local n_rois = 1
+--local n_rois = 2
 local rois=torch.Tensor(n_rois,5)
 for i=1,n_rois do
   idx=torch.randperm(n_images)[1]
   y=torch.randperm(sz[3])[{{1,2}}]:sort()
   x=torch.randperm(sz[2])[{{1,2}}]:sort()
-  --rois[{i,{}}] = torch.Tensor({idx,x[1],y[1],x[2],y[2]})
+  rois[{i,{}}] = torch.Tensor({idx,x[1],y[1],x[2],y[2]})
   --rois[{i,{}}] = torch.Tensor({idx,1,1,sz[3],sz[2]})
   --rois[{i,{}}] = torch.Tensor({idx,1,1,H/2,W/2})
   --rois[{i,{}}] = torch.Tensor({idx,1,1,1,1})
 end
-rois[{1,{}}] = torch.Tensor({1,2,2,3,5})
-rois[{2,{}}] = torch.Tensor({1,1,5,3,6})
+--rois[{1,{}}] = torch.Tensor({1,2,2,3,5})
+--rois[{2,{}}] = torch.Tensor({1,1,5,3,6})
+--rois[{1,{}}] = torch.Tensor({1,1,5,3,6})
 
 print(rois)
 
@@ -70,9 +72,9 @@ print('-------------------------')
 local delta_rois = rois:clone()
 --delta_rois[{{}, {2,5}}] = 0 
 --delta_rois[{{}, {2,5}}] = torch.ones(n_rois, 4) * 0.1 
---delta_rois[{{}, {2,5}}] = torch.rand(n_rois, 4)
+delta_rois[{{}, {2,5}}] = torch.rand(n_rois, 4)
 --delta_rois[{{}, {2,5}}] = torch.Tensor{0.7887, 0.4103, 0.7086, 0.7714}:reshape(1,4)
-delta_rois[{{}, {2,5}}] = torch.Tensor{0.4694, 0.1311, 0.8265, 0.1495, 0.9336, 0.4434, 0.5211, 0.1230}:reshape(2,4)
+--delta_rois[{{}, {2,5}}] = torch.Tensor{0.4694, 0.1311, 0.8265, 0.1495, 0.9336, 0.4434, 0.5211, 0.1230}:reshape(2,4)
 --delta_rois[{{}, {2,5}}] = torch.Tensor{0.4694, 0.1311, 0.8265, 0.1495}:reshape(1,4)
 --delta_rois[{{}, {2,5}}] = torch.Tensor{0.9336, 0.4434, 0.5211, 0.1230}:reshape(1,4)
 print(delta_rois)
@@ -89,8 +91,9 @@ local gradInput = model:backward({input_image:cuda(), rois:cuda(), delta_rois:cu
 --local gradInput = model:backward({input_image:cuda(), rois:cuda(), delta_rois:cuda()}, output)
 print(gradInput[1])
 print(gradInput[1]:sum())
---print(gradInput[2])
+print(gradInput[2])
 print(gradInput[3])
+print(gradInput[3]:sum())
 
 --[[
 local jac = nn.Jacobian

--- a/test/test_roiwarping.lua
+++ b/test/test_roiwarping.lua
@@ -96,6 +96,16 @@ print(gradInput[3]:sum())
 
 --[[
 local jac = nn.Jacobian
+--nn.Jacobian.testJacobian(module, input, minval, maxval, perturbation)
+local perturbation = 1e-3
+local minval = minval or -2
+local maxval = maxval or 2
+local inrange = maxval - minval
+input:copy(torch.rand(input:nElement()):mul(inrange):add(minval))
+local jac_fprop = jac.forward(module, input, input, perturbation)
+local jac_bprop = jac.backward(module, input)
+local error = jac_fprop-jac_bprop
+
 local err = jac.testJacobian(model, {input_image, rois, delta_rois}, nil, nil, 1e-3)
 print(err)
 local b = jac.backward(model, {input_image, rois, delta_rois})

--- a/test/test_roiwarping.lua
+++ b/test/test_roiwarping.lua
@@ -1,0 +1,35 @@
+local inn = require 'inn'
+
+local n_images = 1
+local channels = 3
+local height = 6
+local width = 6
+local sz = torch.Tensor{channels, height, width}
+local input_image = torch.CudaTensor(n_images, sz[1], sz[2], sz[3]):copy(torch.linspace(1, n_images * sz[1] * sz[2] * sz[3], n_images * sz[1] * sz[2] * sz[3]):reshape(n_images, sz[1], sz[2], sz[3]))
+
+print(input_image)
+
+local n_rois = 1
+local rois=torch.CudaTensor(n_rois,5)
+for i=1,n_rois do
+  idx=torch.randperm(n_images)[1]
+  y=torch.randperm(sz[3])[{{1,2}}]:sort()
+  x=torch.randperm(sz[2])[{{1,2}}]:sort()
+  rois[{i,{}}] = torch.Tensor({idx,x[1],y[1],x[2],y[2]})
+  rois[{i,{}}] = torch.Tensor({idx,1,1,sz[3],sz[2]})
+end
+
+print(rois)
+
+local model = inn.ROIPooling(3,3)
+model.v2 = false
+model:cuda()
+
+local output = model:forward({input_image, rois})
+print(output)
+
+local model = inn.ROIWarping(3,3)
+model:cuda()
+local output = model:forward({input_image, rois})
+print(output)
+

--- a/test/test_roiwarping.lua
+++ b/test/test_roiwarping.lua
@@ -25,7 +25,7 @@ end
 local inn = require 'inn'
 local nn = require 'nn'
 
-local n_images = 2
+local n_images = 1
 local channels = 3
 local height = 3
 local width = 6
@@ -38,12 +38,11 @@ local input_image = torch.Tensor(n_images, sz[1], sz[2], sz[3]):copy(torch.linsp
 print(input_image)
 
 local n_rois = 1
---local n_rois = 2
 local rois=torch.Tensor(n_rois,5)
 for i=1,n_rois do
   idx=torch.randperm(n_images)[1]
-  y=torch.randperm(sz[3])[{{1,2}}]:sort()
-  x=torch.randperm(sz[2])[{{1,2}}]:sort()
+  y=torch.randperm(sz[2])[{{1,2}}]:sort()
+  x=torch.randperm(sz[3])[{{1,2}}]:sort()
   rois[{i,{}}] = torch.Tensor({idx,x[1],y[1],x[2],y[2]})
   --rois[{i,{}}] = torch.Tensor({idx,1,1,sz[3],sz[2]})
   --rois[{i,{}}] = torch.Tensor({idx,1,1,H/2,W/2})
@@ -81,14 +80,14 @@ print(delta_rois)
 print(delta_rois_to_rois(rois[{{}, {2,5}}], delta_rois[{{}, {2,5}}]))
 
 local output = model:forward({input_image:cuda(), rois:cuda(), delta_rois:cuda()})
-local output = model:forward({input_image:clone():fill(1):cuda(), rois:cuda(), delta_rois:cuda()})
+--local output = model:forward({input_image:clone():fill(1):cuda(), rois:cuda(), delta_rois:cuda()})
 print(output)
 print(output:sum())
 
 print('-------------------------')
 local gradOutput = torch.ones(n_rois, channels, H, W):cuda() --torch.rand(n_rois, channels, H, W):cuda() --torch.Tensor(n_rois, channels, 3, 3):fill(1)
 local gradInput = model:backward({input_image:cuda(), rois:cuda(), delta_rois:cuda()}, gradOutput)
---local gradInput = model:backward({input_image:cuda(), rois:cuda(), delta_rois:cuda()}, output)
+--local gradInput = model:backward({input_image:clone():fill(1):cuda(), rois:cuda(), delta_rois:cuda()}, gradOutput)
 print(gradInput[1])
 print(gradInput[1]:sum())
 print(gradInput[2])

--- a/test/test_roiwarping.lua
+++ b/test/test_roiwarping.lua
@@ -1,35 +1,94 @@
+local function delta_rois_to_rois(rois, delta_rois)
+  local src_w = rois[{{},3}] - rois[{{},1}] + 1;
+  local src_h = rois[{{},4}] - rois[{{},2}] + 1;
+  local src_ctr_x = rois[{{},1}] + 0.5*(src_w-1.0);
+  local src_ctr_y = rois[{{},2}] + 0.5*(src_h-1.0);
+
+  local dst_ctr_x = delta_rois[{{},1}]; -- dx (in fast-rcnn notation) = cx (in here)
+  local dst_ctr_y = delta_rois[{{},2}]; -- dy (in fast-rcnn notation) = cy (in here)
+  local dst_scl_x = delta_rois[{{},3}]; -- dw (in fast-rcnn notation) = sx (in here)
+  local dst_scl_y = delta_rois[{{},4}]; -- dh (in fast-rcnn notation) = sy (in here)
+
+  local pred_ctr_x = torch.cmul(dst_ctr_x, src_w) + src_ctr_x; 
+  local pred_ctr_y = torch.cmul(dst_ctr_y, src_h) + src_ctr_y; 
+  local pred_w = torch.cmul(torch.exp(dst_scl_x), src_w);            
+  local pred_h = torch.cmul(torch.exp(dst_scl_y), src_h);            
+
+  local roi_start_w = torch.round(pred_ctr_x - 0.5*(pred_w-1)) ; 
+  local roi_start_h = torch.round(pred_ctr_y - 0.5*(pred_h-1)) ; 
+  local roi_end_w =   torch.round(pred_ctr_x + 0.5*(pred_w-1)) ; 
+  local roi_end_h =   torch.round(pred_ctr_y + 0.5*(pred_h-1)) ; 
+
+  return torch.cat({roi_start_w, roi_start_h, roi_end_w, roi_end_h}, 2)
+end
+
 local inn = require 'inn'
+local nn = require 'nn'
 
 local n_images = 1
 local channels = 3
-local height = 6
+local height = 3
 local width = 6
+local H = 4
+local W = 3
+
 local sz = torch.Tensor{channels, height, width}
-local input_image = torch.CudaTensor(n_images, sz[1], sz[2], sz[3]):copy(torch.linspace(1, n_images * sz[1] * sz[2] * sz[3], n_images * sz[1] * sz[2] * sz[3]):reshape(n_images, sz[1], sz[2], sz[3]))
+local input_image = torch.Tensor(n_images, sz[1], sz[2], sz[3]):copy(torch.linspace(1, n_images * sz[1] * sz[2] * sz[3], n_images * sz[1] * sz[2] * sz[3]):reshape(n_images, sz[1], sz[2], sz[3]))
 
 print(input_image)
 
 local n_rois = 1
-local rois=torch.CudaTensor(n_rois,5)
+local rois=torch.Tensor(n_rois,5)
 for i=1,n_rois do
   idx=torch.randperm(n_images)[1]
   y=torch.randperm(sz[3])[{{1,2}}]:sort()
   x=torch.randperm(sz[2])[{{1,2}}]:sort()
-  rois[{i,{}}] = torch.Tensor({idx,x[1],y[1],x[2],y[2]})
+  --rois[{i,{}}] = torch.Tensor({idx,x[1],y[1],x[2],y[2]})
   rois[{i,{}}] = torch.Tensor({idx,1,1,sz[3],sz[2]})
+  --rois[{i,{}}] = torch.Tensor({idx,1,1,H/2,W/2})
+  --rois[{i,{}}] = torch.Tensor({idx,1,1,1,1})
 end
 
 print(rois)
 
-local model = inn.ROIPooling(3,3)
+local model = inn.ROIPooling(W,H)
 model.v2 = false
 model:cuda()
 
-local output = model:forward({input_image, rois})
+local output = model:forward({input_image:cuda(), rois:cuda()})
 print(output)
 
-local model = inn.ROIWarping(3,3)
+local model = inn.ROIWarping(W,H)
 model:cuda()
-local output = model:forward({input_image, rois})
-print(output)
+--local output = model:forward({input_image:cuda(), rois:cuda()})
+--print(output)
 
+---------------
+print('-------------------------')
+local delta_rois = rois:clone()
+delta_rois[{{}, {2,5}}] = 0 
+--delta_rois[{{}, {2,5}}] = torch.ones(n_rois, 4) * 0.1 
+--delta_rois[{{}, {2,5}}] = torch.rand(n_rois, 4)
+--delta_rois[{{}, {2,5}}] = torch.Tensor{0.7887, 0.4103, 0.7086, 0.7714}:reshape(1,4)
+print(delta_rois)
+print(delta_rois_to_rois(rois[{{}, {2,5}}], delta_rois[{{}, {2,5}}]))
+local gradOutput = torch.ones(n_rois, channels, H, W):cuda() --torch.rand(n_rois, channels, H, W):cuda() --torch.Tensor(n_rois, channels, 3, 3):fill(1)
+
+local output = model:forward({input_image:cuda(), rois:cuda(), delta_rois:cuda()})
+print(output)
+print(output:sum())
+
+print('-------------------------')
+local gradInput = model:backward({input_image:cuda(), rois:cuda(), delta_rois:cuda()}, gradOutput)
+print(gradInput[1])
+print(gradInput[1]:sum())
+print(gradInput[2])
+print(gradInput[3])
+
+--[[
+local jac = nn.Jacobian
+local err = jac.testJacobian(model, {input_image, rois, delta_rois}, nil, nil, 1e-3)
+print(err)
+local b = jac.backward(model, {input_image, rois, delta_rois})
+print(b)
+]]


### PR DESCRIPTION
Hi, this is Jaehyun Lim 

I currently working on re-implementing the winning solution of ILSVRC & MSCOCO 2015 competition (http://arxiv.org/abs/1512.04412). 

As a part of the work, I made the ROI warping layer described in the paper. 

Unfortunately, the layer is not complete though. However, I think I want to share it so that somebody can find the bugs that I couldn't find it until now....... 

Note: 
1. The equation (8) in the paper seems to make no sense for me. Thus, I made bilinear warping/mapping as described in Wikipedia. 

2. The backprop (gradient) w.r.t. Image input(or blob) works fine (confirmed with test_jacobian), but the backprop w.r.t. delta_rois (fast-rcnn style rois re-parameterization w.r.t anchors) couldn't make it. 

The backprop w.r.t delta_rois are a bit off from the `nn.Jacobian.forward`. I have tried to found what I might miss, but I couldn't find it until now.

I would appreciate if someone helps me find the bugs. 

Best regards, 

Jaehyun