### PR TITLE
punctuating commands with && to build on windows

### DIFF
--- a/inn-1.0-0.rockspec
+++ b/inn-1.0-0.rockspec
@@ -23,9 +23,7 @@ dependencies = {
 build = {
    type = "command",
    build_command = [[
-cmake -E make_directory build;
-cd build;
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)"
+cmake -E make_directory build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(PREFIX)"
    ]],
    install_command = "cd build && $(MAKE) install"
 }


### PR DESCRIPTION
The (non Power) shell in Windows chokes on this luarock, because it doesn't separate commands with semicolons.